### PR TITLE
Issue #11: invalid invocation of hook_islandora_derivative_alter

### DIFF
--- a/includes/mapper.inc
+++ b/includes/mapper.inc
@@ -66,11 +66,12 @@ function islandora_multi_importer_mapper_get_derivatives($cmodel) {
       array($cmodel),
       array()
     );
-    foreach (islandora_build_hook_list(ISLANDORA_DERIVATIVE_CREATION_HOOK, array($cmodel)) as $hook) {
-      drupal_alter($hook, $derivatives);
-    }
-    uasort($derivatives, 'drupal_sort_weight');
-    return $derivatives;
+  $cmodel_object = islandora_object_load($cmodel);
+  foreach (islandora_build_hook_list(ISLANDORA_DERIVATIVE_CREATION_HOOK, array($cmodel)) as $hook) {
+    drupal_alter($hook, $derivatives, $cmodel_object);
+  }
+  uasort($derivatives, 'drupal_sort_weight');
+  return $derivatives;
 }
 
 


### PR DESCRIPTION
Github ticket: https://github.com/mnylc/islandora_multi_importer/issues/11

# What does this Pull Request do?

Resolves run time error during multi-importer derivative mapping caused by invocation of hook_islandora_derivative_alter without AbstractObject $object argument.

# What's new?

Loads the content model object, and supplies it in the drupal_alter() call.

# How should this be tested?

1. Enable islandora_checksum module (which implements hook_islandora_derivatives_alter() with AbstractObject $object as a required argument).
2. Go to step 2 of the islandora_multi_importer_form.

# Regression testing

 - If any modules that implement this hook expect something different than what we are providing (the cmodel object), it could fail. Not sure how to test for that though!

# Additional Notes:

- Does this change require documentation to be updated?
No.
- Does this change add any new dependencies?
No.
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?
No.
- Could this change impact execution of existing code?
Unknown.