### PR TITLE
This adds 3 ways of dealing with RELS-EXT in case of updates

### DIFF
--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1080,7 +1080,8 @@ function islandora_multi_importer_objectmapping_form($form, &$form_state, $file_
       '#states' => array(
       	'visible' => array(
       		':input[name=action]' => array('value' => 'update'),
-      	)
+      	),
+      ),    
       'label' => array(
         '#markup' => t('RELS-EXT behaviour'),
       ),

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1077,6 +1077,10 @@ function islandora_multi_importer_objectmapping_form($form, &$form_state, $file_
     ),
     'relsext_row' => array(
       '#id' => drupal_html_id('islandora-multi-relsext'),
+      '#states' => array(
+      	'visible' => array(
+      		':input[name=action]' => array('value' => 'update'),
+      	)
       'label' => array(
         '#markup' => t('RELS-EXT behaviour'),
       ),

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1358,11 +1358,11 @@ function islandora_multi_importer_form_submit($form, &$form_state) {
     //@TODO: switch needed here in case we are dealing with FULL CRUD and not only new objects
     // Since those will basically run differently.
     $file = file_load($form_state['storage']['values']['step1']['file']);
+    $file->status = ~FILE_STATUS_PERMANENT; // Keep the uploaded spreadsheet temporary
+    file_save($file);
     file_usage_add($file, 'islandora_batch', 'islandora_batch_set', $setID);
-
-    $batchsetid = $preprocessor->getSetId();
-        
-    drupal_set_message(t('You are all set( <a href="@setreport">id = @set</a>)!', array('@set' => $batchsetid, '@setreport'=>url('admin/reports/islandora_batch_queue/'.$batchsetid))), 'status');
+ 
+    drupal_set_message(t('You are all set( <a href="@setreport">id = @set</a>)!', array('@set' => $setID, '@setreport'=>url('admin/reports/islandora_batch_queue/'.$setID))), 'status');
     
     $theProcessedInfo = $preprocessor->getProcessedObjectsInfo();
     $good_objects = format_plural(count($theProcessedInfo['success']), '%num Objects added successfully to set', '%num Object added successfully to set', array('%num' => count($theProcessedInfo['success'])));

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1075,6 +1075,34 @@ function islandora_multi_importer_objectmapping_form($form, &$form_state, $file_
         ),
       ),
     ),
+    'relsext_row' => array(
+      '#id' => drupal_html_id('islandora-multi-relsext'),
+      'label' => array(
+        '#markup' => t('RELS-EXT behaviour'),
+      ),
+      'relsext_mode' => array(
+        '#type' => 'select',
+        '#attributes' => '',
+        '#description' => t('Select the way you would like to handle predicates for your existing objects'),
+        '#options' => array(
+          'NEW' => 'Only use new Predicates, nothing gets copied over',
+          'MERGE' => 'Only use new Membership Predicates, discard old membership ones but keep anything else',
+          'OLD' => 'Never touch my existing predicates, new cmodel and new parent objects will be ignored',
+        ),
+        '#default_value' => 'NEW',
+        '#states' => array(
+        	'visible' => array(
+        		':input[name=action]' => array('value' => 'update'),
+        	),
+        ),
+      ),
+      'stub' => array(
+        '#markup' => '&nbsp;',
+      ),
+      'stub2' => array(
+        '#markup' => '&nbsp;',
+      ),
+    ),
   );
   $form['objectmapping'] = array(
     '#prefix' => '<div id="islandora-multi-basemapping">',
@@ -1302,7 +1330,7 @@ function islandora_multi_importer_form_submit($form, &$form_state) {
       $parameters = $form_state['storage']['values']['step4'];
       $parameters['source_binaries'] = $form_state['values']['last']['file2'];
     }
-    
+
     // Default action will be ingest.
     // Actually in IslandoraMultiBatch all defaults to ingest
     // except for "update" which means updating existing objects.
@@ -1310,9 +1338,10 @@ function islandora_multi_importer_form_submit($form, &$form_state) {
     // LAST CHECK. IF ACTION is not ingest, we need to make sure that 
     // NO automatic PID is generated.
     $parameters['object_maping']['pidmap_row']['pidtype'] = $parameters['action'] != 'ingest' ? 0 : $parameters['object_maping']['pidmap_row']['pidtype'];
-   
-    
-    
+
+    // Predicates a la carte. 
+    $parameters['object_maping']['relsext_row']['relsext_mode'] = $parameters['action'] == 'ingest' ? 'NEW' : $parameters['object_maping']['relsext_row']['relsext_mode'];
+
     $connection = islandora_get_tuque_connection();
     // kpr($parameters);
     $preprocessor = new IslandoraMultiBatch($connection, $parameters);

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -206,7 +206,9 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
       }
       else {
         // Add this ZIP to the file usage table. That way it will stay even if drupal crons it out.
-        file_usage_add($zipfile, 'islandora_batch', 'islandora_batch_object', $this->setId);
+        $zipfile->status = ~FILE_STATUS_PERMANENT;
+        file_save($zipfile);
+        file_usage_add($zipfile, 'islandora_batch', 'islandora_batch_set', $this->getSetId());
       }
     }
 
@@ -501,7 +503,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
     }
     
     foreach ($files as $file) {
-      $file->status &= ~FILE_STATUS_PERMANENT;
+      $file->status &= ~FILE_STATUS_PERMANENT; // Lets make all files temporary but trust file_usage to keep them around
       file_save($file);
       file_usage_add($file, 'islandora_batch', 'islandora_batch_object', $this->getBatchId());
     }
@@ -552,17 +554,17 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
       $datastreams = $this->getDatastreamsforUpdate($errors, $files, $existing_object);
       if (!empty($errors)) {
         foreach ($errors as $error) {
-          watchdog('islandora_multi_importer', t('There were some issues on Batch set id %setid when generating datastreams for PID %PID: @log', 
+          watchdog('islandora_multi_importer', t('There were some issues on Batch set id @setid when generating datastreams for PID @PID: @log', 
             array(
-              '%setid' => $this->getBatchId(),
-              '%pid' => $this->id,
+              '@setid' => $this->getBatchId(),
+              '@pid' => $this->id,
               '@log' => $error,
             )), WATCHDOG_NOTICE
           );
         }
       }
       foreach ($files as $file) {
-        $file->status &= ~FILE_STATUS_PERMANENT;
+        $file->status &= ~FILE_STATUS_PERMANENT; // Lets make this temporary but trust file_usage to keep them around
         file_save($file);
         file_usage_add($file, 'islandora_batch', 'islandora_batch_object', $this->getBatchId());
       }
@@ -902,7 +904,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
           'label' => $this['RELS-INT']->label,
         ); 
       }
-      dpm($control);
+   
       $newfileNameInt = "RELSINT_update_". urlencode($this->objectInfo['pid']) . '_' . time() . '.xml';
       $newfileInt = file_save_data($this['RELS-INT']->content, "public://" . $newfileNameInt, FILE_EXISTS_RENAME);
       

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -239,6 +239,14 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
         if (!empty($possiblePID)) {
           if (islandora_is_valid_pid($possiblePID)) {
             $objectInfo['pid'] = $possiblePID;
+            // Now be more strict for action = update
+            if ($this->parameters['action'] == 'update') {
+              $existing_object = islandora_object_load($possiblePID);
+              if (!$existing_object) {
+                unset($objectInfo);
+                $invalid = $invalid + array($index => $index);
+              }
+            }  
           }
         }
         if (!isset($objectInfo['pid'])) {
@@ -1131,7 +1139,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
       $this->addContentModelRelationships(); 
       // Copy existing member relationships over;
       if ($relsext_mode != 'NEW') {
-        $this->copyFedoraRels();
+        $this->copyFedoraRels($existing_object);
       }
       if ($relsext_mode != 'OLD') {
       // Sets new member relatiionships over

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -1142,7 +1142,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
         $this->copyFedoraRels($existing_object);
       }
       if ($relsext_mode != 'OLD') {
-      // Sets new member relatiionships over
+      // Sets new member relationships over
         $this->setValidRelationshipsforUpdate($existing_object);
       // sets scratch inheritance (new ones only)
         $this->inheritXacmlPoliciesForUpdate($existing_object); 

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -847,10 +847,9 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
 
     $datastreams = $this->getDatastreams($errors, $files);
     if (isset($this['RELS-EXT']) && !empty($this['RELS-EXT'])) {
-      // Does out existing object already have a RELS-EXT? 
+      // Does our existing object already have a RELS-EXT? 
       // I mean, maybe it is not there? ha.
       if (isset($existing_object['RELS-EXT'])) {
-        
         $control = array(
           'control_group' => $existing_object['RELS-EXT']->controlGroup,
           'mimetype' => $existing_object['RELS-EXT']->mimeType,
@@ -914,7 +913,6 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
     
     return $datastreams;
     }
-
 
   /**
    * Determine the Mimetype for the given file name.
@@ -983,6 +981,48 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
 
     // XXX: Suppressing warnings regarding unregistered prefixes.
     return $processor->transformToXML($input);
+  }
+
+  /**
+   * Copies relevant RELS-EXT from to be updated object.
+   *
+   * @param AbstractObject $sourceObject
+   *   An Object with properties we want to copy over.
+   */
+  protected function copyRels(AbstractObject $sourceObject) {
+    $rels = $sourceObject->relationships->get();
+    foreach ($rels as $relationship) {
+      if (($relationship['predicate']['namespace'] != "info:fedora/fedora-system:def/model#") && 
+      ($relationship['predicate']['namespace']!="info:fedora/fedora-system:def/relations-external#")) {
+        $reltocheck = array();
+        // FEDORA_RELS_EXT_URI.
+        $reltocheck = $this->relationships->get($relationship['predicate']['namespace'],$relationship['predicate']['value']);
+        if (empty($reltocheck)) {
+          $this->relationships->add($relationship['predicate']['namespace'],$relationship['predicate']['value'], $relationship['object']['value'], $relationship['object']['literal']);
+        }
+      }
+    }
+  }
+
+  /**
+   * Copies fedora RELS-EXT from to be updated object.
+   *
+   * @param AbstractObject $sourceObject
+   *   An Object with properties we want to copy over.
+  */
+  protected function copyFedoraRels(AbstractObject $sourceObject) {
+    // All this stuff will be put before the new ones
+    // We can add a switch!
+    $rels = $sourceObject->relationships->get("info:fedora/fedora-system:def/relations-external#");
+    foreach ($rels as $relationship) {
+      $reltocheck = array();
+      // FEDORA_RELS_EXT_URI.
+      $reltocheck = $this->relationships->get($relationship['predicate']['namespace'], $relationship['predicate']['value'], $relationship['object']['value']);
+      // Only copy if not present in batchObject and value of existing is different from new parent
+      if ((empty($reltocheck)) && ($relationship['object']['value']!= $this->objectInfo['parent'] || $relsext_mode == 'OLD')) {
+        $this->relationships->add($relationship['predicate']['namespace'],$relationship['predicate']['value'], $relationship['object']['value'], $relationship['object']['literal']);
+      }
+    }
   }
 
   /**
@@ -1083,16 +1123,28 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
    *  Only valid when ingesting new ones.
    */
   protected function addRelationshipsforUpdate() {
-    // For now will plainly and shamelessly add
-    // new relationships to the DB IngestObject and 
-    // deal with passing those on the preprocessor
-    // @TODO check every existing predicate.. so much.
     $existing_object = islandora_object_load($this->id);
+    $relsext_mode == isset($this->preprocessorParameters['object_maping']['relsext_row']['relsext_mode']) ? $this->preprocessorParameters['object_maping']['relsext_row']['relsext_mode'] : 'NEW';
     if ($existing_object) {
-      $this->addContentModelRelationships(); // restoring this
       // just in case i really want to allow Object transmutation?
-      $this->setValidRelationshipsforUpdate($existing_object);
-      $this->inheritXacmlPoliciesForUpdate($existing_object); 
+      $this->addContentModelRelationships(); 
+      // Copy existing member relationships over;
+      if ($relsext_mode != 'NEW') {
+        $this->copyFedoraRels();
+      }
+      if ($relsext_mode != 'OLD') {
+      // Sets new member relatiionships over
+        $this->setValidRelationshipsforUpdate($existing_object);
+      // sets scratch inheritance (new ones only)
+        $this->inheritXacmlPoliciesForUpdate($existing_object); 
+      // Copies existing relationships to batchObject. Pushing them at the end.
+      // ::copyFedoraRels run first to make sure that if it belongs to any 
+      // other collection previously (or compound!), that is preserved
+      // but the new membership is maintained.
+      }
+      if ($relsext_mode == 'MERGE') {
+        $this->copyRels($existing_object);
+      }
     }
   }
 

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -1142,7 +1142,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
       // other collection previously (or compound!), that is preserved
       // but the new membership is maintained.
       }
-      if ($relsext_mode == 'MERGE') {
+      if ($relsext_mode != 'NEW') {
         $this->copyRels($existing_object);
       }
     }

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -1013,6 +1013,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
   protected function copyFedoraRels(AbstractObject $sourceObject) {
     // All this stuff will be put before the new ones
     // We can add a switch!
+    $relsext_mode = isset($this->preprocessorParameters['object_maping']['relsext_row']['relsext_mode']) ? $this->preprocessorParameters['object_maping']['relsext_row']['relsext_mode'] : 'NEW';
     $rels = $sourceObject->relationships->get("info:fedora/fedora-system:def/relations-external#");
     foreach ($rels as $relationship) {
       $reltocheck = array();
@@ -1124,7 +1125,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
    */
   protected function addRelationshipsforUpdate() {
     $existing_object = islandora_object_load($this->id);
-    $relsext_mode == isset($this->preprocessorParameters['object_maping']['relsext_row']['relsext_mode']) ? $this->preprocessorParameters['object_maping']['relsext_row']['relsext_mode'] : 'NEW';
+    $relsext_mode = isset($this->preprocessorParameters['object_maping']['relsext_row']['relsext_mode']) ? $this->preprocessorParameters['object_maping']['relsext_row']['relsext_mode'] : 'NEW';
     if ($existing_object) {
       // just in case i really want to allow Object transmutation?
       $this->addContentModelRelationships(); 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -380,7 +380,7 @@ function islandora_multi_importer_csv_save(array $data) {
     fclose($fh);
     // Notify the filesystem of the size change
     $file->filesize = filesize($file->uri);
-    $file->status = FILE_STATUS_PERMANENT;
+    $file->status = ~FILE_STATUS_PERMANENT;
     file_save($file);
       
     // Tell the user where we stuck it


### PR DESCRIPTION
I’m trying to be smart here. The idea is that what comes from an existing object’s RELS-EXT into the updated object, given the huge amount of possible use cases, can be managed via 3 choices:

- “MERGE”

 means old relationships (membership included) are migrated into
the object. New predicates are added then and finally, old non-membership predicates are moved too. But any duplicates are discarded.

- “NEW”

 means only new properties are added, nothing from the old
reps-ext is kept.This is the safest approach

- “OLD”

 nothing is added (other than CMODEL really), means whatever
parent you choose is completely ignored and all your previous predicates are kept. Still, some cleanup happens and any duplicated predicate is discarded (useful I hope!)

@nate-rcl can you test this? Still a blind attempt but it should work
out of the box. I hope I did not mess up the logic. I can devote some time tomorrow to address any concerns.