### PR TITLE
Restored call to hook_islandora_multi_importer_remote_file_get

### DIFF
--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -820,15 +820,6 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                     $themime = "text/plain";
                   }
 
-                  // $file = system_retrieve_file($fileurl, $tmpName, FALSE, FILE_EXISTS_RENAME);
-
-                  $file = (object) array(
-                    'uid' => 1,
-                    'uri' => $fileurl,
-                    'filemime' => $themime,
-                    'status' => 1,
-                  );
-
                   $datastreams[$dsid] = array(
                     'dsid' => $dsid,
                     'label' => "$dsid datastream",
@@ -836,7 +827,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                     'datastream_file' => $fileurl,
                     'filename' => drupal_basename($fileurl),
                     'control_group' => 'M',
-                    'file' => $file,
+                    // 'file' => $file,
                   );
                 }
 

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -806,17 +806,29 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                   error_log('can not open ' . $this->preprocessorParameters['zipfile'] . ' with code:'. (int)$opened);
                 }
               }
+
+              // This will handle all cases, except ZIP.
+
               else {
-                // This will handle all cases, except ZIP.
                 $fileurl = islandora_multi_importer_remote_file_get(trim($this->objectInfo['data'][$method[1]]));
                 if ($fileurl) {
                   $themime = $this->getMimetype(drupal_basename($fileurl));
-                      if ($dsid == "HOCR" && $themime == "application/octet-stream") {
-                          $themime = "text/html";
-                      }
-                      if ($dsid == "OCR" && $themime == "application/octet-stream") {
-                          $themime = "text/plain";
-                      }
+                  if ($dsid == "HOCR" && $themime == "application/octet-stream") {
+                    $themime = "text/html";
+                  }
+                  if ($dsid == "OCR" && $themime == "application/octet-stream") {
+                    $themime = "text/plain";
+                  }
+
+                  // $file = system_retrieve_file($fileurl, $tmpName, FALSE, FILE_EXISTS_RENAME);
+
+                  $file = (object) array(
+                    'uid' => 1,
+                    'uri' => $fileurl,
+                    'filemime' => $themime,
+                    'status' => 1,
+                  );
+
                   $datastreams[$dsid] = array(
                     'dsid' => $dsid,
                     'label' => "$dsid datastream",
@@ -824,11 +836,14 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                     'datastream_file' => $fileurl,
                     'filename' => drupal_basename($fileurl),
                     'control_group' => 'M',
-                  // 'file' => $file,.
+                    'file' => $file,
                   );
-                } 
+                }
+
+                // Not found...report the error.
+
                 else { 
-                  $errors[] = t('We tried!, but For Object %id, %dsid datastream: %filename was no where to found',
+                  $errors[] = t('We tried, but For Object %id, %dsid datastream: %filename was nowhere to be found!',
                     array(
                       '%filename' => trim($this->objectInfo['data'][$method[1]]),
                       '%dsid' => $dsid,

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -213,10 +213,10 @@ function islandora_multi_importer_remote_file_get($url) {
     if (!isset($parsed_url['scheme']) || (isset($parsed_url['scheme']) &&!in_array($parsed_url['scheme'], $remote_schemes))) {
 
       // If local file, engage any hook_islandora_multi_importer_remote_file_get and return the real path.
-      $urls = array( );
-      $urls = module_invoke_all('islandora_multi_importer_remote_file_get', $url);
-      if (!empty($urls)) {
-        return drupal_realpath($urls[0]);
+      $path = array( );
+      $path = module_invoke_all('islandora_multi_importer_remote_file_get', $url);
+      if (!empty($path)) {
+        if ($path[0]) { return $path[0]; }
       }
 
       // if local file, return the path.

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -211,6 +211,14 @@ function islandora_multi_importer_remote_file_get($url) {
     $parsed_url = parse_url($url);
     $remote_schemes = array('http', 'https', 'ftp', 'ftps', 'smb', 'nfs');
     if (!isset($parsed_url['scheme']) || (isset($parsed_url['scheme']) &&!in_array($parsed_url['scheme'], $remote_schemes))) {
+
+      // If local file, engage any hook_islandora_multi_importer_remote_file_get and return the real path.
+      $urls = array( );
+      $urls = module_invoke_all('islandora_multi_importer_remote_file_get', $url);
+      if (!empty($urls)) {
+        return drupal_realpath($urls[0]);
+      }
+
       // if local file, return the path.
       return drupal_realpath($url);
     }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -209,8 +209,8 @@ function islandora_multi_importer_xml_highlight($s){
 
 function islandora_multi_importer_remote_file_get($url) {
     $parsed_url = parse_url($url);
-    $remote_schemes = array('http', 'https', 'ftp', 'ftps', 'nfs');
-    if (!isset($parsed_url['scheme']) || (isset($parsed_url['scheme']) &&!in_array($parsed_url['scheme'], $remote_schemes))) {
+    $remote_schemes = array('http', 'https', 'feed');
+    if (!isset($parsed_url['scheme']) || (isset($parsed_url['scheme']) && !in_array($parsed_url['scheme'], $remote_schemes))) {
 
       // If local file, engage any hook_islandora_multi_importer_remote_file_get and return the real path.
       $path = array( );

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -209,7 +209,7 @@ function islandora_multi_importer_xml_highlight($s){
 
 function islandora_multi_importer_remote_file_get($url) {
     $parsed_url = parse_url($url);
-    $remote_schemes = array('http', 'https', 'ftp', 'ftps', 'smb', 'nfs');
+    $remote_schemes = array('http', 'https', 'ftp', 'ftps', 'nfs');
     if (!isset($parsed_url['scheme']) || (isset($parsed_url['scheme']) &&!in_array($parsed_url['scheme'], $remote_schemes))) {
 
       // If local file, engage any hook_islandora_multi_importer_remote_file_get and return the real path.

--- a/islandora_multi_importer.api.php
+++ b/islandora_multi_importer.api.php
@@ -6,36 +6,42 @@
  */
 
 /**
- * Implements hook_islandora_multi_importer_remote_file_get for https://digital.grinnell.edu.
+ * hook_islandora_multi_importer_remote_file_get example from https://digital.grinnell.edu and
+ *   https://dgadmin.grinnell.edu
  *
  * @param $url
- *   Path to the file to be fetched.  Behavior of this hook depends on the transfer scheme specified.
- *     Default behavior strips the 'basename' from $url and looks for that file somewhere in public://imi_files.
- *     @TODO... if smb:// is prepended to the $url implement a Samba file fetch here.
+ *   Path to the file to be fetched.  Default behavior strips the 'basename' from $url and looks
+ *   for that file somewhere in $target.
  * @return array
  *   On error or failure an empty array is returned.
- *   On success, a single array element LOCAL path like /var/www/drupal7/sites/default/files/imi_files/exmample.xml
+ *   On success, a single array element LOCAL path like /mnt/storage/exmample.xml
+ *
+ * Important!  This function requires that your target directory of files be mounted to
+ *   the host server as $target (see below).  The mount statement should look something
+ *   like this:
+ *
+ *  sudo mount -t cifs -o username=mcfatem //storage.grinnell.edu/LIBRARY/mcfatem/PHPP_Content /mnt/storage
+ *
  */
 function hook_islandora_multi_importer_remote_file_get($url) {
-  if ($url === '') {
-    return array();   // return an empty array
-  }
-
+  if ($url === '') { return array(); }  // return an empty array if $url is blank
   $parsed_url = parse_url($url);
 
-  // Assumes the file is somewhere in the public://imi_files path
+  // Assumes the file is somewhere in the /mnt/storage path
+  $target = "/mnt/storage";
 
   $basename = drupal_basename($parsed_url['path']);
   $pattern = "/" . preg_quote($basename) . "/";
   $options['key'] = 'filename';
-  $file = file_scan_directory("public://imi_files", $pattern, $options);
+  $file = file_scan_directory($target, $pattern, $options);
 
   $msg = "IMI hook " . __FUNCTION__ . " was invoked ";
 
   // Nothing found...report and return an empty array.
 
   if (empty($file)) {
-    $msg .= "and was unable to find a file matching '$url' for ingest.";
+    $msg .= "and was unable to find a file matching '$url' in '$target' for ingest. ";
+    $msg .= "Make sure that you have mounted your files as '$target', and that they can be read by 'www-data'!";
     drupal_set_message($msg, 'warning');
     watchdog('Islandora Multi Importer', $msg);
     return array();
@@ -45,8 +51,11 @@ function hook_islandora_multi_importer_remote_file_get($url) {
 
   else {
     $uri = $file[$basename]->uri;
-    $msg .= "and found file '$uri' for ingest.";
+    $msg .= "and found file '$uri' in '$target' for ingest.";
     drupal_set_message($msg, 'status');
     return array($uri);
   }
 }
+
+
+

--- a/islandora_multi_importer.api.php
+++ b/islandora_multi_importer.api.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @file
+ * This file documents all available hook functions to manipulate data.
+ */
+
+/**
+ * Implements hook_islandora_multi_importer_remote_file_get for https://digital.grinnell.edu.
+ *
+ * @param $url
+ *   Path to the file to be fetched.  Behavior of this hook depends on the transfer scheme specified.
+ *     Default behavior strips the 'basename' from $url and looks for that file somewhere in public://imi_files.
+ *     @TODO... if smb:// is prepended to the $url implement a Samba file fetch here.
+ * @return array
+ *   On error or failure an empty array is returned.
+ *   On success, a single array element LOCAL path like /var/www/drupal7/sites/default/files/imi_files/exmample.xml
+ */
+function hook_islandora_multi_importer_remote_file_get($url) {
+  if ($url === '') {
+    return array();   // return an empty array
+  }
+
+  $parsed_url = parse_url($url);
+
+  // Assumes the file is somewhere in the public://imi_files path
+
+  $basename = drupal_basename($parsed_url['path']);
+  $pattern = "/" . preg_quote($basename) . "/";
+  $options['key'] = 'filename';
+  $file = file_scan_directory("public://imi_files", $pattern, $options);
+
+  $msg = "IMI hook " . __FUNCTION__ . " was invoked ";
+
+  // Nothing found...report and return an empty array.
+
+  if (empty($file)) {
+    $msg .= "and was unable to find a file matching '$url' for ingest.";
+    drupal_set_message($msg, 'warning');
+    watchdog('Islandora Multi Importer', $msg);
+    return array();
+  }
+
+  // File found!  Report and send back the URI in an array.
+
+  else {
+    $uri = $file[$basename]->uri;
+    $msg .= "and found file '$uri' for ingest.";
+    drupal_set_message($msg, 'status');
+    return array($uri);
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/mnylc/islandora_multi_importer/issues/41.  

My earlier additions to islandora_multi_importer.api.php document that a hook_islandora_multi_importer_remote_file_get may be employed, but the code to call that hook was removed from utilities.inc.  This PR restores that block of code so that the API document is correct, and so that users can define a hook and override the file get process.  

I found it necessary to do this since smb:// file fetch does not appear to be working (see https://github.com/mnylc/islandora_multi_importer/issues/69). 