### PR TITLE
Issues 85 and 87

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -37,7 +37,7 @@ function islandora_multi_importer_admin_form($form, $form_state) {
   );
   $form['islandora_multi_importer_generalsettings_fieldset']['islandora_multi_importer_extrads'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Allow authorized users to create Datastream not defined in each CMODELS during ingest and update'),
+    '#title' => t('Allow authorized users to create a Datastream not defined in the chosen CMODELs during ingest and update.'),
     '#description' => t('This option also requires corresponding Drupal permissions to be correctly set.'),
     '#default_value' => variable_get('islandora_multi_importer_extrads', FALSE),
   );

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -31,12 +31,18 @@ function islandora_multi_importer_admin_form($form, $form_state) {
   );
   $form['islandora_multi_importer_generalsettings_fieldset']['islandora_multi_importer_plupload'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Use Plupload for ZIP file'),
+    '#title' => t('Use Plupload for uploading spreadsheets and ZIP files'),
     '#description' => t('Use Plupload, requires the Drupal plupload module and Library enabled.'),
     '#default_value' => variable_get('islandora_multi_importer_plupload', FALSE),
   );
-    
-    
+  $form['islandora_multi_importer_generalsettings_fieldset']['islandora_multi_importer_extrads'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Allow authorized users to create Datastream not defined in each CMODELS during ingest and update'),
+    '#description' => t('This option also requires corresponding Drupal permissions to be correctly set.'),
+    '#default_value' => variable_get('islandora_multi_importer_extrads', FALSE),
+  );
+
+
   $form['islandora_multi_importer_googleapi_fieldset'] = array(
     '#type' => 'fieldset',
     '#title' => t('Google API OAuth2 Credentials'),
@@ -49,35 +55,34 @@ function islandora_multi_importer_admin_form($form, $form_state) {
    '#required' => FALSE,
  );
  
-$passexist = variable_get('islandora_multi_importer_googleClientSecret', 0);
+  $passexist = variable_get('islandora_multi_importer_googleClientSecret', 0);
 
 
- $form['islandora_multi_importer_googleapi_fieldset']['islandora_multi_importer_googleClientSecret'] = array(
+  $form['islandora_multi_importer_googleapi_fieldset']['islandora_multi_importer_googleClientSecret'] = array(
   '#type' => 'password',
   '#title' => t('Google API App Secret Key'),
   '#description' => t("Leave as is if you want to keep the existing value"),
   '#required' => !isset($passexist),
-);
+  );
 
-if ($passexist) {
+  if ($passexist) {
   // This will display only if authentication worked out (after, saving)
- $client = islandora_multi_importer_googleclient();
- $authUrl = $client->createAuthUrl(); 
+    $client = islandora_multi_importer_googleclient();
+    $authUrl = $client->createAuthUrl(); 
    
- $form['islandora_multi_importer_googleapi_fieldset']['islandora_multi_importer_googleClientAuthCode'] = array(
-  '#type' => 'password',
-  '#title' => t('Google API Auth Code'),
-  '#description' => t('Leave as is if you want to keep the existing value or Enter from <a href="@google-token" target="_blank">this URL</a>.', array('@google-token' => $authUrl)),
-  '#required' => !isset($passexist),
-);
-}
+    $form['islandora_multi_importer_googleapi_fieldset']['islandora_multi_importer_googleClientAuthCode'] = array(
+      '#type' => 'password',
+      '#title' => t('Google API Auth Code'),
+      '#description' => t('Leave as is if you want to keep the existing value or Enter from <a href="@google-token" target="_blank">this URL</a>.', array('@google-token' => $authUrl)),
+      '#required' => !isset($passexist),
+    );
+  }
 
 
   $form = system_settings_form($form);
   array_unshift($form['#submit'], 'islandora_multi_importer_google_default_password');
 
   return $form;
-
 }
 
 function islandora_multi_importer_google_default_password($form, &$form_state) {
@@ -107,12 +112,8 @@ function islandora_multi_importer_admin_form_validate($form, &$form_state) {
       if ($authCode) {
        $client = islandora_multi_importer_googleclient();
        try {
-       $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
+         $accessToken = $client->fetchAccessTokenWithAuthCode($authCode);
        // And we need to activate it
-       // Probably by invoking the Sheets API directly
-      // Google_Service_Exception: { "error": { "code": 403, "message": "Google Sheets API has not been used in project dmcny-1329 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/sheets.googleapis.com/overview?project=dmcny-1329 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.", "errors": [ { "message": "Google Sheets API has not been used in project dmcny-1329 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/sheets.googleapis.com/overview?project=dmcny-1329 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.", "domain": "global", "reason": "forbidden" } ], "status": "PERMISSION_DENIED" } } in Google_Http_REST::decodeHttpResponse() (line 118 of /vagrant/islandora_host/islandora_multi_importer/vendor/google/apiclient/src/Google/Http/REST.php).
-       
-       
        }
        catch (Exception $e) {
          drupal_set_message(t('@message', array('@message' => check_plain($e->getMessage()))), 'error');
@@ -122,8 +123,6 @@ function islandora_multi_importer_admin_form_validate($form, &$form_state) {
        // This stuff is an array.
        $form_state['values']['islandora_multi_importer_googleClientToken'] = $accessToken;
       }
-   
-    
     //$checkGoogleAPI = islandora_multi_importer_googlecredentials_validate($appid, $secret, $token);
     if (!$accessToken && $authCode) {
       form_set_error('islandora_multi_importer_googleClientSecret', 'Please make sure your Google API OAuth credentials are correct.');
@@ -144,7 +143,6 @@ function islandora_multi_importer_admin_submit_form($form, &$form_state) {
     if (is_array($value) && isset($form_state['values']['array_filter'])) {
       $value = array_keys(array_filter($value));
     }
-    
     variable_set($key, $value);
   }
   drupal_set_message(t('The settings have been updated!'));

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -922,7 +922,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
            ),
          );
          $form['extrads']['newdsid']['addmenu']['save'] = array(
-           '#prefix' => '<div class="form-group" id="islandora-multi-newdsidsave">',
+           '#prefix' => '<div id="islandora-multi-newdsidsave">',
            '#suffix' => '</div>',
            '#access' => ($form_state['triggering_element']['#value'] == t('Add an extra DSID')),
            '#tree' => TRUE,
@@ -947,8 +947,8 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
              '#type' => 'button',
              '#value' => t('Cancel'),
              '#ajax' => array(
-               'callback' => 'function islandora_multi_importer_saveextradsid_ajax',
-               'wrapper' => 'islandora-multi-newdsid',
+               'callback' => 'islandora_multi_importer_saveextradsid_ajax',
+               'wrapper' => 'islandora-multi-newdsidsave',
              ),
            ),
          );

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -933,17 +933,13 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
              '#default_value' => 'DWC',
              '#element_validate' => array('islandora_multi_importer_validate_dsid'),
            ),
-           
-           
-           
-           
            'realsave' => array(
              '#tree' => TRUE,
              '#type' => 'submit',
              '#value' => t('Add this DWC to every CMODEL'),
              '#ajax' => array(
                'callback' => 'islandora_multi_importer_saveextradsid_ajax',
-               'wrapper' => 'islandora-multi-twigsave',
+               'wrapper' => 'islandora-multi-newdsidsave',
              ),
            ),
            'cancel' => array(
@@ -1308,7 +1304,7 @@ function islandora_multi_importer_adddsid_ajax($form, &$form_state) {
  * Add DSID callback for ajax driven form.
  */
 function islandora_multi_importer_saveextradsid_ajax($form, &$form_state) {
-  return $form['cmodelmap']['cmodels']['extrads'];
+  return $form['cmodelmap']['cmodels']['extrads']['addmenu']['save'];
 }
 
 function islandora_multi_importer_validate_dsid($element, $form_state) {

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -851,6 +851,11 @@ function islandora_multi_importer_cmodelmapping_form(array $form, array &$form_s
     $form['basemapping']['rows'][$key] = $row;
   }
   $form['cmodels'] = islandora_multi_importer_cmodeldsmapping_form($form_state, $file_data);
+  
+  // Allows users to add extra DSIDS not defined in each CMODEL
+  
+  
+  
   return $form;
 }
 
@@ -875,7 +880,82 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
   // Only if cmodels where computed previously.
   if (isset($form_state['storage']['values']['general']['computed_cmodels'])) {
     $computed_cmodels = $form_state['storage']['values']['general']['computed_cmodels'];
+    // Deal with user-supplied DSDIs
+    if (user_access(ISLANDORA_MULTI_IMPORTER_EXTRADS) && variable_get('islandora_multi_importer_extrads', FALSE)) {
+       $form['extrads'] = array(
+         '#tree' => TRUE,
+         '#type' => 'markup',
+       );
+       $form['extrads']['newdsid'] = array(
+         '#prefix' => '<div class="form-group" id="islandora-multi-newdsid">',
+         '#suffix' => '</div>',
+         '#title' => t('Add custom Datastreams not defined in computed datastreams'),
+         '#tree' => TRUE,
+         '#type' => 'fieldset',
+       );
+       
+       $form['extrads']['newdsid']['addmenu']['presave'] = array(
+         '#prefix' => '<div style="height:50px;">',
+         '#suffix' => '</div>',
+         '#tree' => TRUE,
+         '#type' => 'button',
+         '#value' => t('Add an extra DSID'),
+         '#access' => ($form_state['triggering_element']['#value'] != t('Add an extra DSID')),
+         '#ajax' => array(
+           'callback' => 'islandora_multi_importer_adddsid_ajax',
+           'wrapper' => 'islandora-multi-newdsid',
+         ),
+       );
 
+       // This one is only displayed if the Add an extra DSID button was pressed.
+       if (isset($form_state['clicked_button']) && ($form_state['clicked_button']['#value'] == 'Add an extra DSID')) {
+         $form['extrads']['newdsid']['addmenu']['presave'] = array(
+           '#prefix' => '<div style="height:50px;">',
+           '#suffix' => '</div>',
+           '#tree' => TRUE,
+           '#type' => 'button',
+           '#value' => t('Add an extra DSID'),
+           '#access' => ($form_state['triggering_element']['#value'] != t('Add an extra DSID')),
+           '#ajax' => array(
+             'callback' => 'islandora_multi_importer_adddsid_ajax',
+             'wrapper' => 'islandora-multi-newdsid',
+           ),
+         );
+         $form['extrads']['newdsid']['addmenu']['save'] = array(
+           '#prefix' => '<div class="form-group" id="islandora-multi-newdsidsave">',
+           '#suffix' => '</div>',
+           '#access' => ($form_state['triggering_element']['#value'] == t('Add an extra DSID')),
+           '#tree' => TRUE,
+           'dsid_name' => array(
+             '#type' => 'textfield',
+             '#description' => 'New datastream ID (DSID)',
+             '#default_value' => 'DWC',
+           ),
+           
+           
+           
+           
+           'realsave' => array(
+             '#tree' => TRUE,
+             '#type' => 'submit',
+             '#value' => t('Add this DWC to every CMODEL'),
+             '#ajax' => array(
+               'callback' => 'islandora_multi_importer_saveextradsid_ajax',
+               'wrapper' => 'islandora-multi-twigsave',
+             ),
+           ),
+           'cancel' => array(
+             '#tree' => TRUE,
+             '#type' => 'button',
+             '#value' => t('Cancel'),
+             '#ajax' => array(
+               'callback' => 'function islandora_multi_importer_saveextradsid_ajax',
+               'wrapper' => 'islandora-multi-newdsid',
+             ),
+           ),
+         );
+     }
+  }
     foreach ($computed_cmodels as $cmodel => $dsids) {
       $form[$cmodel] = array(
         '#type' => 'fieldset',
@@ -954,6 +1034,9 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
             }
           }
         }
+        
+        dpm($options);
+        
         // Check if DS is optional or not, we enforce not optional ones.
         $defaults[$dsid] = !$dsidinfo['optional'];
         $form[$cmodel]['dsid']['rows'][$dsid] = array(
@@ -1180,7 +1263,7 @@ function islandora_multi_importer_previstwig_ajax($form, &$form_state) {
 }
 
 /**
- * Save template  allback for ajax driven form.
+ * Save template callback for ajax driven form.
  */
 function islandora_multi_importer_savetwig_ajax($form, &$form_state) {
   return $form['step4']['group_tabs']['group_twig_tab']['savemenu'];
@@ -1206,6 +1289,22 @@ function islandora_multi_importer_loadtwig_ajax($form, &$form_state) {
 function islandora_multi_importer_mapper_ajax($form, &$form_state) {
   return $form['cmodelmap']['cmodels'];
 }
+
+
+/**
+ * Add DSID callback for ajax driven form.
+ */
+function islandora_multi_importer_adddsid_ajax($form, &$form_state) {
+  return $form['cmodelmap']['cmodels']['extrads'];
+}
+
+/**
+ * Add DSID callback for ajax driven form.
+ */
+function islandora_multi_importer_saveextradsid_ajax($form, &$form_state) {
+  return $form['cmodelmap']['cmodels']['extrads'];
+}
+
 
 
 /**

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -936,10 +936,10 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
            'realsave' => array(
              '#tree' => TRUE,
              '#type' => 'submit',
-             '#value' => t('Add this DWC to every CMODEL'),
+             '#value' => t('Add this DSID to every CMODEL'),
              '#ajax' => array(
                'callback' => 'islandora_multi_importer_saveextradsid_ajax',
-               'wrapper' => 'islandora-multi-newdsidsave',
+               'wrapper' => 'islandora-multi-cmodelmapping',
              ),
            ),
            'cancel' => array(
@@ -954,6 +954,19 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
          );
      }
   }
+   if (empty(form_get_errors()) && isset($form_state['clicked_button']) && ($form_state['clicked_button']['#value'] == 'Add this DSID to every CMODEL')) {
+        foreach ($computed_cmodels as $cmodel => $dsid) {
+          $new_dsdi = trim($form_state['values']['cmodelmap']['cmodels']['extrads']['newdsid']['addmenu']['save']['dsid_name']);
+          $computed_cmodels[$cmodel] += array(
+            "$new_dsdi" => array(
+              'id' => $new_dsdi,
+              'mime'=> array(),
+              'optional' => 1
+            )
+          );
+        } 
+   }
+
     foreach ($computed_cmodels as $cmodel => $dsids) {
       $form[$cmodel] = array(
         '#type' => 'fieldset',
@@ -1014,7 +1027,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
           'application/rdf+xml',
           'text/plain',
           'text/html',
-        ))) {
+        )) || empty($dsidinfo['mime'])){
           // In case no template is there yet (first install)?
           if (!empty($template_options)) {
             $options['Use Twig Template'] = array_combine(array_map($prefix_options, $template_options, array_fill(0, count($template_options), "template|")), $template_options);
@@ -1304,14 +1317,14 @@ function islandora_multi_importer_adddsid_ajax($form, &$form_state) {
  * Add DSID callback for ajax driven form.
  */
 function islandora_multi_importer_saveextradsid_ajax($form, &$form_state) {
-  return $form['cmodelmap']['cmodels']['extrads']['addmenu']['save'];
+  return $form['cmodelmap']['cmodels'];
 }
 
-function islandora_multi_importer_validate_dsid($element, &$form_state) {
+function islandora_multi_importer_validate_dsid($element, &$form_state, $form) {
   module_load_include('inc', 'islandora', 'includes/utilities');
- 
-  //orm_set_error('values']['extrads']['newdsid']['addmenu']['save']['dsid_name','Wrong DSID name format');
-  form_error($element, t('Your DSID is not valid'));
+  if (!islandora_multi_importer_isValidXmlName($element['#value'])) {
+    form_set_error('cmodelmap][cmodels][extrads][newdsid][addmenu][save][dsid_name','');
+  }
 }
 
 

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -877,6 +877,9 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
     '#type' => 'markup',
   );
   $rows = array();
+  // Check action here.
+  $parameters['action'] = isset($form_state['values']['action']) ? $form_state['values']['action'] : 'ingest';
+  
   // Only if cmodels where computed previously.
   if (isset($form_state['storage']['values']['general']['computed_cmodels'])) {
     $computed_cmodels = $form_state['storage']['values']['general']['computed_cmodels'];
@@ -1014,7 +1017,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
           $options['via XSLT from MODS'] = array('xlst|0' => 'default XSLT');
         }
 
-        if ($dsidinfo['optional'] == TRUE) {
+        if (($dsidinfo['optional'] == TRUE) || ($parameters['action']!= 'ingest')){
           $options['NONE'] = array('' => t("-- Don't Create --"));
         }
         $options['Via a source data field (file path)'] = $field_options;

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -931,7 +931,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
              '#size' => 64,
              '#description' => 'New datastream ID (DSID)',
              '#default_value' => 'DWC',
-             '#element_validate' => array('islandora_multi_importer_validatedsid'),
+             '#element_validate' => array('islandora_multi_importer_validate_dsid'),
            ),
            
            

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -928,8 +928,10 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
            '#tree' => TRUE,
            'dsid_name' => array(
              '#type' => 'textfield',
+             '#size' => 64,
              '#description' => 'New datastream ID (DSID)',
              '#default_value' => 'DWC',
+             '#element_validate' => array('islandora_multi_importer_validatedsid'),
            ),
            
            
@@ -989,6 +991,10 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
       // Iterate over existing ones
       // Defaults.
       $defaults = array();
+      
+      // NEW DSID goes here...
+      
+      
       foreach ($dsids as $dsid => $dsidinfo) {
 
         // Individual Options for each DSID.
@@ -1303,6 +1309,13 @@ function islandora_multi_importer_adddsid_ajax($form, &$form_state) {
  */
 function islandora_multi_importer_saveextradsid_ajax($form, &$form_state) {
   return $form['cmodelmap']['cmodels']['extrads'];
+}
+
+function islandora_multi_importer_validate_dsid($element, $form_state) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  dpm($form_state['values']);
+  dpm($form_state['values']['extrads']['newdsid']['addmenu']['save']['dsid_name']);
+  form_error($element, t('Your DSID is not valid'));
 }
 
 

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1037,7 +1037,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
           }
         }
         
-        dpm($options);
+        
         
         // Check if DS is optional or not, we enforce not optional ones.
         $defaults[$dsid] = !$dsidinfo['optional'];
@@ -1307,10 +1307,11 @@ function islandora_multi_importer_saveextradsid_ajax($form, &$form_state) {
   return $form['cmodelmap']['cmodels']['extrads']['addmenu']['save'];
 }
 
-function islandora_multi_importer_validate_dsid($element, $form_state) {
+function islandora_multi_importer_validate_dsid($element, &$form_state) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   dpm($form_state['values']);
   dpm($form_state['values']['extrads']['newdsid']['addmenu']['save']['dsid_name']);
+  form_set_error('values']['extrads']['newdsid']['addmenu']['save']['dsid_name','Wrong DSID name format');
   form_error($element, t('Your DSID is not valid'));
 }
 

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1309,9 +1309,8 @@ function islandora_multi_importer_saveextradsid_ajax($form, &$form_state) {
 
 function islandora_multi_importer_validate_dsid($element, &$form_state) {
   module_load_include('inc', 'islandora', 'includes/utilities');
-  dpm($form_state['values']);
-  dpm($form_state['values']['extrads']['newdsid']['addmenu']['save']['dsid_name']);
-  form_set_error('values']['extrads']['newdsid']['addmenu']['save']['dsid_name','Wrong DSID name format');
+ 
+  //orm_set_error('values']['extrads']['newdsid']['addmenu']['save']['dsid_name','Wrong DSID name format');
   form_error($element, t('Your DSID is not valid'));
 }
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -558,3 +558,27 @@ function islandora_multi_importer_array_equallyseize($headercount, $row) {
         
     return $row;
 }
+
+/**
+ * Checks if a given value can be used as Fedora object DSID
+ *
+ * @param string $dsid
+ *   the dsid candidate
+ * @return bool
+ *  True if it can be used as DSID 
+ */
+function islandora_multi_importer_isValidXmlName($dsid) {
+  $dsid = trim($dsid);
+  // see https://wiki.duraspace.org/display/FEDORA38/Fedora+Identifiers
+  if ((strlen($dsid)>64) || (strlen($dsid)==0)) {
+    return FALSE;
+  }
+
+  try {
+    new DOMElement($dsid);
+      return TRUE;
+  } catch(DOMException $e) {
+      return FALSE;
+  }
+}
+

--- a/islandora_multi_importer.module
+++ b/islandora_multi_importer.module
@@ -139,7 +139,11 @@ function islandora_multi_importer_permission() {
     ),
     ISLANDORA_MULTI_IMPORTER_TWIGMANAGE => array(
       'title' => t('Manage Islandora Multi Importer Twig templates'),
-      'description' => t('Manage user-supplied Twig templates'),
+      'description' => t('Manage user-supplied Twig templates in Islandora Multi Importer.'),
+    ),
+    ISLANDORA_MULTI_IMPORTER_EXTRADS => array(
+      'title' => t('Create/update Datastreams not defined in CMODELS.'),
+      'description' => t('Allow user-supplied DSIDS to be used in any CMODELS.'),
     ),
   );
 }

--- a/islandora_multi_importer.module
+++ b/islandora_multi_importer.module
@@ -9,8 +9,8 @@
 // Permissions.
 define('ISLANDORA_MULTI_IMPORTER_CREATE', 'Import Objects using Islandora Multi Importer');
 define('ISLANDORA_MULTI_IMPORTER_UPDATE', 'Update Objects using Islandora Multi Importer');
-define('ISLANDORA_MULTI_IMPORTER_TWIGMANAGE', "Manage Islandora Multi Importer Twig templates");
-
+define('ISLANDORA_MULTI_IMPORTER_TWIGMANAGE', 'Manage Islandora Multi Importer Twig templates');
+define('ISLANDORA_MULTI_IMPORTER_EXTRADS', 'Add new DSIDS to Islandora Multi Importer imports');
 
 /**
  * Implements hook_init().


### PR DESCRIPTION
Enables custom DS (includes special permission and admin option) #82 and solves #87 by allowing, if "ingest" action is "update", a "don't create"option as valid input source even if the Datastream is marked as enforced/required by a given CMODEL.

 @kimpham54 for #85 @McFateM @Natkeeran@McFateM @kllhwang @jmignault for #87 