### PR TITLE
Fix row index going out of scope on pagination and arbitrary parent/child row order

### DIFF
--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -520,7 +520,9 @@ function islandora_multi_importer_twig_form($form, &$form_state, $file_data) {
 
   if (isset($form_state['values']['step3']['sheet_content'])) {
     $current_row = isset($form_state['values']['step3']['sheet_content']['rows']) && 
-      !empty($form_state['values']['step3']['sheet_content']['rows']) ?  $form_state['values']['step3']['sheet_content']['rows'] : key($file_data['data']);
+      !empty($form_state['values']['step3']['sheet_content']['rows']) &&
+      isset($file_data['data'][$form_state['values']['step3']['sheet_content']['rows']])
+      ? $form_state['values']['step3']['sheet_content']['rows'] : key($file_data['data']);
     $current_record_record_data = array('data' => islandora_multi_importer_array_combine_special($file_data['headers'], $file_data['data'][$current_row]));
 
     

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -796,7 +796,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                 if (!$fp) {
                     $errors[] = t('For Object %id, %dsid datastream: We could not find the source %file file in the expected location, will try to get it remotely',
                     array(
-                      '%file' => $$this->objectInfo['data'][$method[1]],
+                      '%filename' => trim($this->objectInfo['data'][$method[1]]),
                       '%dsid' => $dsid,
                       '%id' => $this->id,
                     ));

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -301,6 +301,7 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
           $parent_hash[$parent][$index] = $index;
           $parentchilds = array();
           // Lets check if the index actually exists before going crazy.
+          
           if (!isset($file_data_all['data'][$parent])) {
             $invalid[$parent] = $parent;
             $invalid[$index] = $index;
@@ -381,6 +382,17 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
     }
     // Ok, maybe this is expensive, so let's try it first so.
     // TODO: optimize maybe?
+    
+    // New first pass: ensure parents have always a PID first
+    // since rows/parent/child order could be arbitrary
+    foreach ($parent_hash as $parent => $children) {
+      if (isset($info[$parent])) {
+        $namespace = $info[$parent]['namespace'];
+        $info[$parent]['pid'] = isset($info[$parent]['pid']) ? $info[$parent]['pid'] : $this->getInternalIdentifier($namespace, $namespace_count[$namespace]);
+      }
+    }
+    
+    // Now the real pass, iterate over every row.
     foreach ($info as $index => &$objectInfo) {
       $namespace = $objectInfo['namespace'];
       $objectInfo['pid'] = isset($objectInfo['pid']) ? $objectInfo['pid'] : $this->getInternalIdentifier($namespace, $namespace_count[$namespace]);


### PR DESCRIPTION
# What does this pull do?

See #103 

This checks if and old selected row index exists or not when Ajax triggers a reload on data preview pagination, if not, it defaults back to the first element in the new page, allowing everything to flow again. Also. This allows arbitrary parent /child ordering (parent index) in a spreadsheet. Means you can have page Objects in row 1-N and then a book in row N+1. And the first ones referring to that N+1 row as parent. It adds a bit more complexity to my code, but it seems to be working.

# How to test?

Select a row for preview, move between pages in the data preview, select another. No AJAX errors or logged errors should be there.

@kllhwang please test. Its online in our dev server.

