### PR TITLE
Issue-116: Allow a full override of not optional Datastreams per CMODEL

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -41,6 +41,12 @@ function islandora_multi_importer_admin_form($form, $form_state) {
     '#description' => t('This option also requires corresponding Drupal permissions to be correctly set.'),
     '#default_value' => variable_get('islandora_multi_importer_extrads', FALSE),
   );
+  $form['islandora_multi_importer_generalsettings_fieldset']['islandora_multi_importer_dontenforceds'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Do not enforce required/not optional Datastreams as defined in each CMODEL.'),
+    '#description' => t('This option overrides the CMODEL Datastream optional=false property completely. Means you can create objects with missing datastreams, with the exception of DC which is a Fedora requirement and MODS(when defined), which normally is the source of DC in Islandora'),
+    '#default_value' => variable_get('islandora_multi_importer_dontenforceds', FALSE),
+  );
 
 
   $form['islandora_multi_importer_googleapi_fieldset'] = array(

--- a/includes/googleapi.inc
+++ b/includes/googleapi.inc
@@ -43,6 +43,10 @@ function islandora_multi_importer_googleclient() {
  */
 function islandora_multi_importer_googleclient_authwithtoken($client, $tokens) {
   //Tokens is the whole array in form of
+  if (isset($tokens['error']) && !empty($tokens['error'])) {
+    drupal_set_message(t('Google OAuth Error, probably your credentials expired. Please set them correctly again in your IMI Config page.'),'warning', 'FALSE');
+    return $client;
+  }
   $client->setAccessToken($tokens);
   
 // Refresh the token if expired.
@@ -53,7 +57,7 @@ function islandora_multi_importer_googleclient_authwithtoken($client, $tokens) {
        variable_set('islandora_multi_importer_googleClientToken', $tokens);
     }
     else {
-      drupal_set_message(t('Google Error, probably your credentials expired'));
+      drupal_set_message(t('Google Error, probably your credentials expired'),'warning','FALSE');
     }
   }
   else {

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1014,10 +1014,13 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
 
         // Individual Options for each DSID.
         $options = array();
+        $default_option = NULL;
         // Exception for DC, allow XSLT.
         if ($dsid == 'DC') {
           // @TODO add XLST options and other sources diff than mods
           $options['via XSLT from MODS'] = array('xlst|0' => 'default XSLT');
+          // Make this the default for DC
+          $default_option = 'xlst|0';
         }
 
         if (($dsidinfo['optional'] == TRUE) || ($parameters['action']!= 'ingest') || variable_get('islandora_multi_importer_dontenforceds', FALSE)){
@@ -1037,6 +1040,9 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
           // In case no template is there yet (first install)?
           if (!empty($template_options)) {
             $options['Use Twig Template'] = array_combine(array_map($prefix_options, $template_options, array_fill(0, count($template_options), "template|")), $template_options);
+            if (empty($default_option)) {
+              $default_option = reset($options['Use Twig Template']);
+            }
           }
         }
 
@@ -1055,8 +1061,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
             }
           }
         }
-        
-        
+
         
         // Check if DS is optional or not, we enforce not optional ones.
         $defaults[$dsid] = !$dsidinfo['optional'];
@@ -1070,6 +1075,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
               '#attributes' => array(),
               '#description' => t('Select the way you want to build this DS'),
               '#options' => $options,
+              '#default_value' => $default_option,
             ),
           ),
         );

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1020,7 +1020,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
           $options['via XSLT from MODS'] = array('xlst|0' => 'default XSLT');
         }
 
-        if (($dsidinfo['optional'] == TRUE) || ($parameters['action']!= 'ingest')){
+        if (($dsidinfo['optional'] == TRUE) || ($parameters['action']!= 'ingest') || variable_get('islandora_multi_importer_dontenforceds', FALSE)){
           $options['NONE'] = array('' => t("-- Don't Create --"));
         }
         $options['Via a source data field (file path)'] = $field_options;
@@ -1060,6 +1060,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
         
         // Check if DS is optional or not, we enforce not optional ones.
         $defaults[$dsid] = !$dsidinfo['optional'];
+
         $form[$cmodel]['dsid']['rows'][$dsid] = array(
           '#title' => $dsid,
           'dsid' => array('#markup' => $dsid),

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1041,7 +1041,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
           if (!empty($template_options)) {
             $options['Use Twig Template'] = array_combine(array_map($prefix_options, $template_options, array_fill(0, count($template_options), "template|")), $template_options);
             if (empty($default_option)) {
-              $default_option = reset($options['Use Twig Template']);
+              $default_option = "template|" . reset($options['Use Twig Template']);
             }
           }
         }
@@ -1057,6 +1057,9 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
               } 
               else {
                 $options['Derivatives'] = array('derivative|0' => 'Build using islandora generated derivative');
+              }
+              if (empty($default_option)) {
+                $default_option = 'derivative|0';
               }
             }
           }

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1188,7 +1188,7 @@ function islandora_multi_importer_objectmapping_form($form, &$form_state, $file_
         '#description' => t('Select public accesible resource location'),
         '#options' => array(
           'REMOTE' => 'AWS S3/Dropbox via http(s)',
-          'LOCAL' => 'local*',
+          'LOCAL' => 'local (in your server) or no files needed/provided',
           'ZIP' => 'ZIP',
         ),
       ),

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1023,7 +1023,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
           $default_option = 'xlst|0';
         }
 
-        if (($dsidinfo['optional'] == TRUE) || ($parameters['action']!= 'ingest') || variable_get('islandora_multi_importer_dontenforceds', FALSE)){
+        if (($dsidinfo['optional'] == TRUE) || ($parameters['action']!= 'ingest') || (variable_get('islandora_multi_importer_dontenforceds', FALSE) && $dsid != 'MODS')){
           $options['NONE'] = array('' => t("-- Don't Create --"));
         }
         $options['Via a source data field (file path)'] = $field_options;

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1041,7 +1041,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
           if (!empty($template_options)) {
             $options['Use Twig Template'] = array_combine(array_map($prefix_options, $template_options, array_fill(0, count($template_options), "template|")), $template_options);
             if (empty($default_option)) {
-              $default_option = "template|" . reset($options['Use Twig Template']);
+              $default_option = 'template|' . reset($options['Use Twig Template']);
             }
           }
         }
@@ -1058,9 +1058,8 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
               else {
                 $options['Derivatives'] = array('derivative|0' => 'Build using islandora generated derivative');
               }
-              if (empty($default_option)) {
-                $default_option = 'derivative|0';
-              }
+              // Derivative wins over Template in like a second!
+              $default_option = 'derivative|0';
             }
           }
         }

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -748,7 +748,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
             $twig_input['name'] = $method[1];
             $twig_input['template'] = $template;
             $twig_input['data'] = array('data' => array_combine($this->preprocessorParameters['data']['headers'], $this->objectInfo['data']));
-            // @TODO should we validate the template again heincludesre?
+            // @TODO should we validate the template again?
             $twig_output = islandora_multi_importer_twig_process($twig_input);
             // Check if this is can be a DomDocument of some sort.
             $docmimetype = $this->preprocessorParameters['computed_cmodels'][$this->objectInfo['cmodel']][$dsid]['mime'][0];

--- a/islandora_multi_importer.install
+++ b/islandora_multi_importer.install
@@ -72,3 +72,20 @@ function islandora_multi_importer_schema() {
 
 function islandora_multi_importer_enable() {
 }
+
+/**
+ * Implements hook_uninstall().
+ */
+function islandora_multi_importer_uninstall() {
+
+  $variables = array(
+    'islandora_multi_importer_plupload',
+    'islandora_multi_importer_extrads',
+    'islandora_multi_importer_dontenforceds',
+    'islandora_multi_importer_googleClientID',
+    'islandora_multi_importer_googleClientSecret',
+    'islandora_multi_importer_googleClientToken',
+    'islandora_multi_importer_googleClientAuthCode',
+  );
+  array_walk($variables, 'variable_del');
+}


### PR DESCRIPTION
# What is new?

See #116 

This pull adds an option in IMI's admin config (admin/islandora/tools/multi_importer) that overrides our CMODEL sanity checking for required/optional datastreams and adds, if the new checkbox is enabled, an all over the place  --Don't Create-- Option, except, if present, for MODS, when enforced 
(Hope this makes sense!)

This pull also adds a kinda better message in case the Google Token has expired and does not allow a grant again, which will happen if you test this pull by saving the config form and you had not make changes recently to your credentials (old old old). 

Finally, most expected i guess, it makes some quite rough decisions for you/defaults when setting the CMODEL mapping. Now some Datastreams will show certain defaults instead of the first option in the settings, allowing you for the first time to click less and enjoy more.

@bondjimbond as promised, here it is and its still Friday! Please test this branch. We can still tune some options here, always in the context of course of that original ISSUE. Also, if you set everything to DON'T CREATE, ingest will not happen and you will get again the error 

` Serious datastream issues on @pid have forced us to not ingest it.` Which will always trigger if your OBJECT is 100% datastreamless, for whatever reason that is. I hardcoded that so.
If you require empty Objects to be ingested, we need to talk about this


