### PR TITLE
ISSUE-119: One PDF to rule them all (not all really just the Book)

### DIFF
--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -974,6 +974,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
    }
 
     foreach ($computed_cmodels as $cmodel => $dsids) {
+      $pdf_to_tiffoptions =[];
       $form[$cmodel] = array(
         '#type' => 'fieldset',
         '#tree' => TRUE,
@@ -1002,6 +1003,11 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
       };
 
       $field_options = array_combine(array_map($prefix_options, array_keys($file_data['headers']), array_fill(0, count($file_data['headers']), "column|")), array_values($file_data['headers']));
+      if (in_array($cmodel, ['islandora:pageCModel', 'islandora:newspaperPageCModel'])) {
+        $pdf_to_tiffoptions = array_combine(array_map($prefix_options, array_keys($file_data['headers']), array_fill(0, count($file_data['headers']), "parent_pdf|")), array_values($file_data['headers']));
+      }
+
+
       $template_options = islandora_multi_importer_twig_list();
       // Iterate over existing ones
       // Defaults.
@@ -1027,6 +1033,9 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
           $options['NONE'] = array('' => t("-- Don't Create --"));
         }
         $options['Via a source data field (file path)'] = $field_options;
+        if (($dsid == 'OBJ') && in_array($cmodel, ['islandora:pageCModel', 'islandora:newspaperPageCModel'])) {
+          $options['Page Image extracted from Parent Object PDF'] = $pdf_to_tiffoptions;
+        }
         // Todo, add other mime types we can create with Twig
         // (RDF, turtle, html, whatever is not binary)
         if (array_intersect($dsidinfo['mime'], array(

--- a/includes/import.form.inc
+++ b/includes/import.form.inc
@@ -1004,7 +1004,7 @@ function islandora_multi_importer_cmodeldsmapping_form(array &$form_state, array
 
       $field_options = array_combine(array_map($prefix_options, array_keys($file_data['headers']), array_fill(0, count($file_data['headers']), "column|")), array_values($file_data['headers']));
       if (in_array($cmodel, ['islandora:pageCModel', 'islandora:newspaperPageCModel'])) {
-        $pdf_to_tiffoptions = array_combine(array_map($prefix_options, array_keys($file_data['headers']), array_fill(0, count($file_data['headers']), "parent_pdf|")), array_values($file_data['headers']));
+        $pdf_to_tiffoptions = array_combine(array_map($prefix_options, array_keys($file_data['headers']), array_fill(0, count($file_data['headers']), "parent_object|")), array_values($file_data['headers']));
       }
 
 

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -1035,12 +1035,20 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                   $fileurl = "zip://" . str_replace(" ", "\x20", $this->preprocessorParameters['zipfile']) . "#" . trim($this->objectInfo['data'][$method[1]]);
 
                   if ($method[0] == 'parent_object') {
+                    // islandora paged can not deal with zipped files sadly
+                    // we need a temp one
+                    $tmp_directory = islandora_multi_importer_temp_directory();
+                    $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info['PATHINFO_EXTENSION'];
+                    if (!file_exists($destination)) {
+                      $temp_pdf = file_unmanaged_copy($fileurl, $destination, FILE_EXISTS_REPLACE);
+                    }
+
                     $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
 
                     error_log($fileurl);
                     error_log($device);
                     error_log($offset);
-                    $fileurl = islandora_paged_content_extract_tiff_from_pdf($fileurl, $offset, $device, $resolution);
+                    $fileurl = islandora_paged_content_extract_tiff_from_pdf($temp_pdf, $offset, $device, $resolution);
                     // Get path info agaain for the returned mimetype
                     $path_info = pathinfo(str_replace(" ", "\x20", trim($fileurl)));
                     $themime = "image/tiff";

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -513,6 +513,8 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
     // In specific ones that are going to Borrow a PDF from the parent's OBJ
     // Should we also clear the Parent's OBJ afterwards?
     foreach ($special_children_hash as $child) {
+      dpm($child);
+
       if (isset($info[$child])) {
         $parent = $info[$child]['parent'];
         $source_datastream = $info[$child]['parent_object_obj'];
@@ -522,9 +524,13 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
         // Two conditions will apply for generating
         // 1.- Only one page present (master to be used as template data)
         // 2.- a Sequence number of eXaCtLY == 0. Easy peasy
+        dpm($parent_hash[$parent]);
+        dpm($info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']]);
+        dpm($info[$child]['data'][$source_datastream]);
+
         if (count($parent_hash[$parent]) == 1 &&
           (int) $info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] == 0 &&
-          strlen(trim($info[$child]['data'][$source_datastream]) > 4 )
+          strlen(trim($info[$child]['data'][$source_datastream])) > 4
         ) {
           // So 5, is a single character, a dot and the pdf extension or the ps extension
           // Means we need a lot of extra pages based on the PDF info info.
@@ -1039,7 +1045,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                     // islandora paged can not deal with zipped files sadly
                     // we need a temp one
                     $tmp_directory = islandora_multi_importer_temp_directory();
-                    $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info['PATHINFO_EXTENSION'];
+                    $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info[PATHINFO_EXTENSION];
                     if (!file_exists($destination)) {
                       $success = file_put_contents($destination, $fp);
                     }

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -891,41 +891,6 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
         if (!empty($howtogenerate['method']['data'])) {
           $method = explode("|", $howtogenerate['method']['data']);
           switch ($method[0]) {
-            case 'parent_object':
-              $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
-              $resolution = 300;
-              $device = isset($this->preprocessorParameters['pdf_device']) ? $this->preprocessorParameters['pdf_device'] : 'tiff24nc';
-              error_log($this->objectInfo['data'][$method[1]]);
-              error_log($device);
-              error_log($offset);
-              $url = islandora_paged_content_extract_tiff_from_pdf(trim($this->objectInfo['data'][$method[1]]), $offset, $device, $resolution);
-              if ($url) {
-              $path_info = pathinfo(str_replace(" ", "\x20", trim($url)));
-              $filename = $path_info['filename'];
-              $dslabel = substr($filename,0,255);
-              //remove any trailing spaces
-              $dslabel = trim($dslabel);
-              $dslabel = !empty($dslabel) ? $dslabel : "$dsid datastream";
-              $datastreams[$dsid] = array(
-                'dsid' => $dsid,
-                'label' => $dslabel,
-                'mimetype' => 'image/tiff',
-                'datastream_file' => $url,
-                'filename' => $path_info['basename'],
-                'control_group' => 'M',
-              );
-              }
-              else {
-                $errors[] = t('For Object %id, %dsid datastream: we could process/extract TIFF from PDF %filename',
-                  array(
-                    '%filename' => trim($this->objectInfo['data'][$method[1]]),
-                    '%dsid' => $dsid,
-                    '%id' => $this->id,
-                  ));
-              }
-             break;
-
-
             case 'derivative':
             // Nothing to do really, derivative processing will do the job.
             break;
@@ -984,6 +949,10 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
             );
             break;
 
+            case 'parent_object':
+              $resolution = 300;
+              $device = isset($this->preprocessorParameters['pdf_device']) ? $this->preprocessorParameters['pdf_device'] : 'tiff24nc';
+            // Will deal same as column but with a twist
             case 'column':
             // This means our source field contains a file path or and url
             // if file path, we need to know if local of ZIP
@@ -1009,9 +978,22 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                   // try to get it now from remote
                   $fileurl = islandora_multi_importer_remote_file_get(trim($this->objectInfo['data'][$method[1]]));
                   $themime = "application/octet-stream";
+
+                  if ($method[0] == 'parent_object' && $fileurl) {
+                    $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
+
+                    error_log($this->objectInfo['data'][$method[1]]);
+                    error_log($device);
+                    error_log($offset);
+                    $fileurl = islandora_paged_content_extract_tiff_from_pdf($fileurl, $offset, $device, $resolution);
+                    // Get path info agaain for the returned mimetype
+                    $path_info = pathinfo(str_replace(" ", "\x20", trim($fileurl)));
+                    $themime = "image/tiff";
+                  }
+
+
                   if ($fileurl) { 
                     $themime = property_exists($fileurl, 'filemime') ? $fileurl->filemime : $this->getMimetype($path_info['basename']);
-                
                     if ($dsid == "HOCR" && $themime == "application/octet-stream") {
                       $themime = "text/html";
                     }
@@ -1023,7 +1005,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                     //remove any trailing spaces
                     $dslabel = trim($dslabel);
                     $dslabel = !empty($dslabel) ? $dslabel : "$dsid datastream";
-                    
+
                     $datastreams[$dsid] = array(
                       'dsid' => $dsid,
                       'label' => $dslabel,
@@ -1045,10 +1027,24 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                   }
                 } 
                 else {
-                  // This means we have the file insize the ZIP.
+                  // This means we have the file inside the ZIP.
                   // Deal with non extensions when inside a ZIP
                  
                   $themime = $this->getMimetype($path_info['basename']);
+                  $fileurl = "zip://" . str_replace(" ", "\x20", $this->preprocessorParameters['zipfile']) . "#" . trim($this->objectInfo['data'][$method[1]]);
+
+                  if ($method[0] == 'parent_object') {
+                    $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
+
+                    error_log($this->objectInfo['data'][$method[1]]);
+                    error_log($device);
+                    error_log($offset);
+                    $fileurl = islandora_paged_content_extract_tiff_from_pdf($fileurl, $offset, $device, $resolution);
+                    // Get path info agaain for the returned mimetype
+                    $path_info = pathinfo(str_replace(" ", "\x20", trim($fileurl)));
+                    $themime = "image/tiff";
+                  }
+
                   if ($dsid == "HOCR" && $themime == "application/octet-stream") {
                     $themime = "text/html";
                   }
@@ -1065,7 +1061,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                     'dsid' => $dsid,
                     'label' => $dslabel,
                     'mimetype' => $themime,
-                    'datastream_file' => "zip://" . str_replace(" ", "\x20", $this->preprocessorParameters['zipfile']) . "#" . trim($this->objectInfo['data'][$method[1]]),
+                    'datastream_file' => $fileurl,
                     'filename' => $path_info['basename'],
                     'control_group' => 'M',
                   );
@@ -1086,6 +1082,16 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
 
             else {
               $fileurl = islandora_multi_importer_remote_file_get(trim($this->objectInfo['data'][$method[1]]));
+              if ($method[0] == 'parent_object' && $fileurl) {
+                $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
+                error_log($fileurl);
+                error_log($device);
+                error_log($offset);
+                $fileurl = islandora_paged_content_extract_tiff_from_pdf($fileurl, $offset, $device, $resolution);
+                // Get path info agaain for the returned mimetype
+                $path_info = pathinfo(str_replace(" ", "\x20", trim($fileurl)));
+                $themime = "image/tiff";
+              }
 
               $themime = "application/octet-stream";
               if ($fileurl) {

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -970,7 +970,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
 
             case 'parent_object':
               $resolution = 300;
-              $device = isset($this->preprocessorParameters['pdf_device']) ? $this->preprocessorParameters['pdf_device'] : 'tiff24nc';
+              $device = isset($this->preprocessorParameters['pdf_device']) ? $this->preprocessorParameters['pdf_device'] : 'tiff32nc';
             // Will deal same as column but with a twist
             case 'column':
             // This means our source field contains a file path or and url

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -167,6 +167,94 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
     return $added;
   }
 
+  protected function getPdfInfo($fileasstring) {
+    $pages = FALSE;
+    $errors = [];
+    $fileurl = $this->getMeAFile($fileasstring, $errors);
+    foreach($errors as $error) {
+      drupal_set_message($error, 'warning');
+    }
+    if ($fileurl) {
+      try {
+        $pages = islandora_paged_content_length_of_pdf($fileurl);
+      }
+      catch (Exception $exception) {
+        drupal_set_message(t('We could not get the number of pages from @file needed to generate the objects', ['@file' => $fileasstring]), 'warning');
+
+      }
+    }
+    return $pages;
+  }
+
+
+  protected function getMeAFile($fileasstring, array &$errors = []){
+
+    $path_info = pathinfo(str_replace(" ", "\x20", trim($fileasstring)));
+    $filename = $path_info['filename'];
+
+    if (isset($this->parameters['zipfile']) && !empty($this->parameters['zipfile'])) {
+      // Fetch one file from provided ZIP file.
+      $z = new ZipArchive();
+      $opened = FALSE;
+      $opened = $z->open($this->parameters['zipfile']);
+      if ($opened === TRUE) {
+        $fp = $z->getStream($fileasstring);
+        if (!$fp) {
+          $errors[] = t('We could not find a needed source %file file in the expected location, will try to get it remotely',
+            array(
+              '%filename' => trim($fileasstring),
+            ));
+          // The file does not exist.
+          // try to get it now from remote
+          $fileurl = islandora_multi_importer_remote_file_get(trim($fileasstring));
+           if ($fileurl) {
+             // We can really not trust mime type in this scenario
+            return $fileurl;
+          }
+          else {
+            $errors[] = t('We could not find a needed source %file file no where, so giving up',
+              array(
+                '%filename' => trim($fileasstring),
+              ));
+            return FALSE;
+          }
+        }
+        else {
+          // This means we have the file inside the ZIP.
+          // Deal with non extensions when inside a ZIP
+          return  "zip://" . str_replace(" ", "\x20", $this->parameters['zipfile']) . "#" . trim($fileasstring);
+        }
+        $z->close();
+      }
+      else {
+        $errors[] = t('Provided ZIP file %zipfile can not be opened or is invalid. Code %errorcode.',
+          array(
+            '%zipfile' => $this->preprocessorParameters['zipfile'],
+            '%errorcode' => (int)$opened,
+          ));
+        return FALSE;
+      }
+    }
+    // This will handle all cases, except ZIP.
+    else {
+      $fileurl = islandora_multi_importer_remote_file_get(trim($fileasstring));
+      if ($fileurl) {
+        return $fileurl;
+      }
+      else {
+
+        $errors[] = t('We tried but we could not find a needed source %filename file was nowhere to be found. giving up',
+          array(
+            '%filename' => trim($fileasstring),
+          ));
+        return FALSE;
+      }
+    }
+  }
+
+
+
+
   /**
    * {@inheritdoc}
    */
@@ -215,6 +303,11 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
     $namespace_hash = array();
     // Keeps track of all parents and child that don't have a PID assigned.
     $parent_hash = array();
+
+    // October 2020: Keeps track of all children that need OBJs from parents
+
+    $special_children_hash = array();
+
     $namespace_count = array();
     $info = array();
     // Keeps track of invalid rows.
@@ -230,14 +323,37 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
       $possiblePID = "";
       
       $objectInfo['data'] = $row;
-       
+
+      // October 2020: Check if any of the rows/future objects needs to use the parent OBJ as source
+      // Right now we only accept PDFs in a Book or Newspaper
+      // Pages (1 or more) will have a special "parent OBJ" mapping
+      // But we do not need to check the CMODEL since the UI limits who can already
+      if (isset($this->parameters['cmodel_mapping'][$objectInfo['cmodel']]['dsid']['OBJ'])) {
+        $howtogenerate = $this->parameters['cmodel_mapping'][$objectInfo['cmodel']]['dsid']['rows']['OBJ'];
+        // We do not have access to the parent yet here. So we just flag it
+        if (strpos($howtogenerate['method']['data'], "parent_object|") === 0 ) {
+        // Means we got os a cross dependant Page to Parent OBJ case
+        // BUT. To allow also books that have their own! images in OBJ present
+         $method = explode("|", $howtogenerate['method']['data']);
+         $parent_dsid = $method[1];
+          // WE will do an extra check. The actual parent mapped column needs to be empty
+          // In the current object. If not treat as a normal page
+          // Further down we will also do extra checks!
+          if (strlen(trim($objectInfo['data'][$parent_dsid])) == 0) {
+            $objectInfo['parent_object_obj'] = $parent_dsid;
+            $special_children_hash[$i] = $i;
+          }
+       }
+      }
+
+
+
       // Autogeneration of PID is enabled and a PID column is provided
       // both modes complement/limit each other
       // in case of update or any other action that is npt ingest, always check for existing PID
       if (($this->parameters['object_maping']['pidmap_row']['pidtype']) != 1 || $this->parameters['action']!= 'ingest') {
         // User provided PIDs are not required to respect collection policies, namespace, etc.
         $possiblePID = trim($row[$this->parameters['object_maping']['pidmap_row']['pidmap']]);
-        
         if (!empty($possiblePID)) {
           if (islandora_is_valid_pid($possiblePID)) {
             $objectInfo['pid'] = $possiblePID;
@@ -279,7 +395,7 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
             }
             else {
               // we have a PID but i still want my objectInfo['namespace']
-              // NO worries about checking if pidparts is in fact lenght of 2
+              // NO worries about checking if pidparts is in fact length of 2
               // PID was checked for sanity a little bit earlier
               $pidparts = explode(":", $objectInfo['pid']);
               $objectInfo['namespace'] = $pidparts[0];
@@ -391,7 +507,46 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
         $info[$parent]['pid'] = isset($info[$parent]['pid']) ? $info[$parent]['pid'] : $this->getInternalIdentifier($namespace, $namespace_count[$namespace]);
       }
     }
-    
+
+    // Now we need to preprocess Children with Special parent needs
+    // In specific ones that are going to Borrow a PDF from the parent's OBJ
+    // Should we also clear the Parent's OBJ afterwards?
+    foreach ($special_children_hash as $child) {
+      if (isset($info[$child])) {
+        $parent = $info[$child]['parent'];
+        $source_datastream = $info[$child]['parent_object_obj'];
+        // This is where we copy!
+        $info[$child]['data'][$source_datastream] = $info[$parent]['data'][$source_datastream];
+        // But that is not enough! Now we need to figure out if we need to generate pages or only use existing ones
+        // Two conditions will apply for generating
+        // 1.- Only one page present (master to be used as template data)
+        // 2.- a Sequence number of eXaCtLY == 0. Easy peasy
+        if (count($parent_hash[$parent]) == 1 &&
+          $info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] == 0 &&
+          strlen(trim($info[$child]['data'][$source_datastream]) > 4 )
+        ) {
+          // So 5, is a single character, a dot and the pdf extension or the ps extension
+          // Means we need a lot of extra pages based on the PDF info info.
+          // GOSH I CREATED A MONSTER!
+          $number_of_pages = $this->getPdfInfo($info[$child]['data'][$source_datastream]);
+          if ($number_of_pages) {
+            // First update sequence number of the first one to 1
+            $info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] = 1;
+            $labelmap = $this->parameters['object_maping']['labelmap_row']['labelmap'];
+            $number_of_pages = $number_of_pages - 1; // because yea, maybe someone just got one!
+            foreach($number_of_pages as $pagenumber ) {
+              $theclone = $info[$child];
+              $theclone['data'][$labelmap] =  $theclone['data'][$labelmap] . ' ' . $pagenumber;
+              $info[] = $theclone;
+            }
+            $namespace = $info[$child]['namespace'];
+            $namespace_count[$namespace] = $namespace_count[$namespace] + $number_of_pages;
+          }
+        }
+      }
+    }
+
+
     // Now the real pass, iterate over every row.
     foreach ($info as $index => &$objectInfo) {
       $namespace = $objectInfo['namespace'];
@@ -493,6 +648,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
    * Function batchProcessforIngest.
    */
   protected function batchProcessforIngest() {
+     $setid = $this->getBatchId();
       if ($this->deriveDC) {
           // Do this only once.
           $xsl = new DOMDocument;
@@ -500,9 +656,9 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
           if (!$xsl) {
               // Disable transform if this is the case
               $this->deriveDC = FALSE; 
-              $parms = array('@setid' => $setid, '@pid' => $this->id, '@log' => 'Could not load global XSLT for MODS2DC transformation. MODS to DC disabled!');
+              $params = array('@setid' => $setid, '@pid' => $this->id, '@log' => 'Could not load global XSLT for MODS2DC transformation. MODS to DC disabled!');
               $msg = 'There were some issues on Batch set id @setid when loading DC to MODS via XSLT: @log';
-              watchdog('islandora_multi_importer', $msg, $parms, WATCHDOG_NOTICE);
+              watchdog('islandora_multi_importer', $msg, $params, WATCHDOG_NOTICE);
           }
       }
       // Use object_info to create some datastreams.
@@ -512,11 +668,10 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
       $datastreams = array();
       $datastreams = $this->getDatastreams($errors, $files);
       if (!empty($errors)) {
-          $setid = $this->getBatchId();
           foreach ($errors as $error) {
-              $parms = array('@setid' => $setid, '@pid' => $this->id, '@log' => $error );
+              $params = array('@setid' => $setid, '@pid' => $this->id, '@log' => $error );
               $msg = 'There were some issues on Batch set id @setid when generating datastreams for PID @pid: @log';
-              watchdog('islandora_multi_importer', $msg, $parms, WATCHDOG_NOTICE);
+              watchdog('islandora_multi_importer', $msg, $params, WATCHDOG_NOTICE);
           }
       }
       if (empty($datastreams)) {
@@ -616,7 +771,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
       if (!empty($errors)) {
         $setid = $this->getBatchId();
         foreach ($errors as $error) {
-          $parms = array('@setid' => $setid, '@pid' => $this->id, '@log' => $error );
+          $params = array('@setid' => $setid, '@pid' => $this->id, '@log' => $error );
           $msg = 'There were some issues on Batch set id @setid when generating datastreams for PID @pid: @log';
           watchdog('islandora_multi_importer', $msg, $params, WATCHDOG_NOTICE);
         }
@@ -733,6 +888,38 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
         if (!empty($howtogenerate['method']['data'])) {
           $method = explode("|", $howtogenerate['method']['data']);
           switch ($method[0]) {
+            case 'parent_object':
+              $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
+              $resolution = 300;
+              $device = isset($this->preprocessorParameters['pdf_device']) ? $this->preprocessorParameters['pdf_device'] : 'tiff24nc';
+              $url = islandora_paged_content_extract_tiff_from_pdf(trim($this->objectInfo['data'][$method[1]]), $offset, $device, $resolution);
+              if ($url) {
+              $path_info = pathinfo(str_replace(" ", "\x20", trim($url)));
+              $filename = $path_info['filename'];
+              $dslabel = substr($filename,0,255);
+              //remove any trailing spaces
+              $dslabel = trim($dslabel);
+              $dslabel = !empty($dslabel) ? $dslabel : "$dsid datastream";
+              $datastreams[$dsid] = array(
+                'dsid' => $dsid,
+                'label' => $dslabel,
+                'mimetype' => 'image/tiff',
+                'datastream_file' => $url,
+                'filename' => $path_info['basename'],
+                'control_group' => 'M',
+              );
+              }
+              else {
+                $errors[] = t('For Object %id, %dsid datastream: we could process/extract TIFF from PDF %filename',
+                  array(
+                    '%filename' => trim($this->objectInfo['data'][$method[1]]),
+                    '%dsid' => $dsid,
+                    '%id' => $this->id,
+                  ));
+              }
+             break;
+
+
             case 'derivative':
             // Nothing to do really, derivative processing will do the job.
             break;
@@ -783,7 +970,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
             $files[] = $newfile;
             $datastreams[$dsid] = array(
               'dsid' => $dsid,
-              'label' => "$dsid datastream ",
+              'label' => "$dsid datastream",
               'mimetype' => $docmimetype,
               'datastream_file' => drupal_realpath($newfile->uri),
               'filename' => $newfileName,

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -228,7 +228,7 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
           // Deal with non extensions when inside a ZIP
           $tmp_directory = islandora_multi_importer_temp_directory();
           $fileurl = "zip://" . str_replace(" ", "\x20", $this->parameters['zipfile']) . "#" . trim($fileasstring);
-          $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info[PATHINFO_EXTENSION];
+          $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info['extension'];
           if (!file_exists($destination)) {
             $success = file_put_contents($destination, $fp);
           }
@@ -1060,7 +1060,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                     // islandora paged can not deal with zipped files sadly
                     // we need a temp one
                     $tmp_directory = islandora_multi_importer_temp_directory();
-                    $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info[PATHINFO_EXTENSION];
+                    $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info['extension'];
                     if (!file_exists($destination)) {
                       $success = file_put_contents($destination, $fp);
                     }

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -523,7 +523,7 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
         // 1.- Only one page present (master to be used as template data)
         // 2.- a Sequence number of eXaCtLY == 0. Easy peasy
         if (count($parent_hash[$parent]) == 1 &&
-          $info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] == 0 &&
+          (int) $info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] == 0 &&
           strlen(trim($info[$child]['data'][$source_datastream]) > 4 )
         ) {
           // So 5, is a single character, a dot and the pdf extension or the ps extension

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -555,8 +555,8 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
             // First update sequence number of the first one to 1
             $info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] = 1;
             $labelmap = $this->parameters['object_maping']['labelmap_row']['labelmap'];
-            $number_of_pages = $number_of_pages - 1; // because yea, maybe someone just got one!
-            foreach($number_of_pages as $pagenumber ) {
+             // because yea, maybe someone just got one!
+            for($i = 1 ; $i < $number_of_pages; $i++) {
               $theclone = $info[$child];
               $theclone['data'][$labelmap] =  $theclone['data'][$labelmap] . ' ' . $pagenumber;
               $info[] = $theclone;

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -342,7 +342,7 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
           // Further down we will also do extra checks!
           if (strlen(trim($objectInfo['data'][$parent_dsid])) == 0) {
             $objectInfo['parent_object_obj'] = $parent_dsid;
-            $special_children_hash[$i] = $i;
+            $special_children_hash[$index] = $index;
           }
        }
       }

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -209,6 +209,7 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
           // try to get it now from remote
           $fileurl = islandora_multi_importer_remote_file_get(trim($fileasstring));
            if ($fileurl) {
+             $z->close();
              // We can really not trust mime type in this scenario
             return $fileurl;
           }
@@ -217,13 +218,27 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
               array(
                 '%filename' => trim($fileasstring),
               ));
+            $z->close();
             return FALSE;
+
           }
         }
         else {
           // This means we have the file inside the ZIP.
           // Deal with non extensions when inside a ZIP
-          return  "zip://" . str_replace(" ", "\x20", $this->parameters['zipfile']) . "#" . trim($fileasstring);
+          $tmp_directory = islandora_multi_importer_temp_directory();
+          $fileurl = "zip://" . str_replace(" ", "\x20", $this->parameters['zipfile']) . "#" . trim($fileasstring);
+          $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info[PATHINFO_EXTENSION];
+          if (!file_exists($destination)) {
+            $success = file_put_contents($destination, $fp);
+          }
+          error_log($fileurl);
+          error_log($destination);
+
+          if ($success) {
+            $z->close();
+            return $destination;
+          }
         }
         $z->close();
       }
@@ -1051,7 +1066,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                     }
 
                     $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
-
+                    $offset = ($offset > 0 ) ? (int) $offset : 1;
                     error_log($success);
                     error_log($fileurl);
                     error_log($device);

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -229,6 +229,7 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
           $tmp_directory = islandora_multi_importer_temp_directory();
           $fileurl = "zip://" . str_replace(" ", "\x20", $this->parameters['zipfile']) . "#" . trim($fileasstring);
           $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info['extension'];
+          $success = TRUE;
           if (!file_exists($destination)) {
             $success = file_put_contents($destination, $fp);
           }
@@ -1056,6 +1057,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                     // we need a temp one
                     $tmp_directory = islandora_multi_importer_temp_directory();
                     $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info['extension'];
+                    $success = TRUE;
                     if (!file_exists($destination)) {
                       $success = file_put_contents($destination, $fp);
                     }

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -168,6 +168,7 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
   }
 
   protected function getPdfInfo($fileasstring) {
+    module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
     $pages = FALSE;
     $errors = [];
     $fileurl = $this->getMeAFile($fileasstring, $errors);
@@ -880,6 +881,8 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
   protected function getDatastreams(&$errors = NULL, &$files = NULL) {
     module_load_include('inc', 'islandora', 'includes/utilities');
     module_load_include('inc', 'islandora_multi_importer', 'includes/utilities');
+    module_load_include('inc', 'islandora_paged_content', 'includes/utilities');
+
 
     $datastreams = array();
 

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -1035,20 +1035,26 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                   $fileurl = "zip://" . str_replace(" ", "\x20", $this->preprocessorParameters['zipfile']) . "#" . trim($this->objectInfo['data'][$method[1]]);
 
                   if ($method[0] == 'parent_object') {
+                    error_log('should be in the ZIP');
                     // islandora paged can not deal with zipped files sadly
                     // we need a temp one
                     $tmp_directory = islandora_multi_importer_temp_directory();
                     $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info['PATHINFO_EXTENSION'];
                     if (!file_exists($destination)) {
-                      $temp_pdf = file_unmanaged_copy($fileurl, $destination, FILE_EXISTS_REPLACE);
+                      $success = file_put_contents($destination, $fp);
                     }
 
                     $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
 
+                    error_log($success);
                     error_log($fileurl);
                     error_log($device);
                     error_log($offset);
-                    $fileurl = islandora_paged_content_extract_tiff_from_pdf($temp_pdf, $offset, $device, $resolution);
+
+                    if ($success) {
+                      $fileurl = islandora_paged_content_extract_tiff_from_pdf($destination, $offset, $device, $resolution);
+                    }
+                    error_log($fileurl);
                     // Get path info agaain for the returned mimetype
                     $path_info = pathinfo(str_replace(" ", "\x20", trim($fileurl)));
                     $themime = "image/tiff";
@@ -1134,7 +1140,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
 
                 // Not found...report the error.
                 
-                $errors[] = t('We tried, but For Object %id, %dsid datastream: %filename was nowhere to be found!',
+                $errors[] = t('We tried, but For Object %id, %dsid datastream: %filename was no where to be found!',
                 array(
                   '%filename' => trim($this->objectInfo['data'][$method[1]]),
                   '%dsid' => $dsid,

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -895,6 +895,9 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
               $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
               $resolution = 300;
               $device = isset($this->preprocessorParameters['pdf_device']) ? $this->preprocessorParameters['pdf_device'] : 'tiff24nc';
+              error_log($this->objectInfo['data'][$method[1]]);
+              error_log($device);
+              error_log($offset);
               $url = islandora_paged_content_extract_tiff_from_pdf(trim($this->objectInfo['data'][$method[1]]), $offset, $device, $resolution);
               if ($url) {
               $path_info = pathinfo(str_replace(" ", "\x20", trim($url)));

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -232,8 +232,6 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
           if (!file_exists($destination)) {
             $success = file_put_contents($destination, $fp);
           }
-          error_log($fileurl);
-          error_log($destination);
 
           if ($success) {
             $z->close();
@@ -528,7 +526,6 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
     // In specific ones that are going to Borrow a PDF from the parent's OBJ
     // Should we also clear the Parent's OBJ afterwards?
     foreach ($special_children_hash as $child) {
-      dpm($child);
 
       if (isset($info[$child])) {
         $parent = $info[$child]['parent'];
@@ -539,9 +536,6 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
         // Two conditions will apply for generating
         // 1.- Only one page present (master to be used as template data)
         // 2.- a Sequence number of eXaCtLY == 0. Easy peasy
-        dpm($parent_hash[$parent]);
-        dpm($info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']]);
-        dpm($info[$child]['data'][$source_datastream]);
 
         if (count($parent_hash[$parent]) == 1 &&
           (int) $info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] == 0 &&
@@ -555,14 +549,17 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
             // First update sequence number of the first one to 1
             $info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] = 1;
             $labelmap = $this->parameters['object_maping']['labelmap_row']['labelmap'];
+            $info[$child]['data'][$labelmap] = $info[$child]['data'][$labelmap] . ' ' . 1;
              // because yea, maybe someone just got one!
             for($i = 1 ; $i < $number_of_pages; $i++) {
               $theclone = $info[$child];
-              $theclone['data'][$labelmap] =  $theclone['data'][$labelmap] . ' ' . $pagenumber;
+              $theclone['data'][$labelmap] =  $theclone['data'][$labelmap] . ' ' . $i;
+              $theclone['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] = $i;
               $info[] = $theclone;
             }
             $namespace = $info[$child]['namespace'];
-            $namespace_count[$namespace] = $namespace_count[$namespace] + $number_of_pages;
+            // One less since we already had the 0 sequence master page.
+            $namespace_count[$namespace] = $namespace_count[$namespace] + $number_of_pages - 1;
           }
         }
       }
@@ -988,7 +985,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
               $opened = $z->open($this->preprocessorParameters['zipfile']);
               if ($opened === TRUE) {
                 $fp = $z->getStream($this->objectInfo['data'][$method[1]]);
-                error_log($this->objectInfo['data'][$method[1]]);
+
                 if (!$fp) {
                     $errors[] = t('For Object %id, %dsid datastream: We could not find the source %file file in the expected location, will try to get it remotely',
                     array(
@@ -1004,9 +1001,6 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                   if ($method[0] == 'parent_object' && $fileurl) {
                     $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
 
-                    error_log($this->objectInfo['data'][$method[1]]);
-                    error_log($device);
-                    error_log($offset);
                     $fileurl = islandora_paged_content_extract_tiff_from_pdf($fileurl, $offset, $device, $resolution);
                     // Get path info agaain for the returned mimetype
                     $path_info = pathinfo(str_replace(" ", "\x20", trim($fileurl)));
@@ -1056,7 +1050,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                   $fileurl = "zip://" . str_replace(" ", "\x20", $this->preprocessorParameters['zipfile']) . "#" . trim($this->objectInfo['data'][$method[1]]);
 
                   if ($method[0] == 'parent_object') {
-                    error_log('should be in the ZIP');
+
                     // islandora paged can not deal with zipped files sadly
                     // we need a temp one
                     $tmp_directory = islandora_multi_importer_temp_directory();
@@ -1067,15 +1061,12 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
 
                     $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
                     $offset = ($offset > 0 ) ? (int) $offset : 1;
-                    error_log($success);
-                    error_log($fileurl);
-                    error_log($device);
-                    error_log($offset);
+
 
                     if ($success) {
                       $fileurl = islandora_paged_content_extract_tiff_from_pdf($destination, $offset, $device, $resolution);
                     }
-                    error_log($fileurl);
+
                     // Get path info agaain for the returned mimetype
                     $path_info = pathinfo(str_replace(" ", "\x20", trim($fileurl)));
                     $themime = "image/tiff";
@@ -1120,9 +1111,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
               $fileurl = islandora_multi_importer_remote_file_get(trim($this->objectInfo['data'][$method[1]]));
               if ($method[0] == 'parent_object' && $fileurl) {
                 $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
-                error_log($fileurl);
-                error_log($device);
-                error_log($offset);
+
                 $fileurl = islandora_paged_content_extract_tiff_from_pdf($fileurl, $offset, $device, $resolution);
                 // Get path info agaain for the returned mimetype
                 $path_info = pathinfo(str_replace(" ", "\x20", trim($fileurl)));

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -551,7 +551,7 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
             $info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] = 1;
             $labelmap = $this->parameters['object_maping']['labelmap_row']['labelmap'];
              // because yea, maybe someone just got one!
-            for($i = 1 ; $i < $number_of_pages; $i++) {
+            for($i = 2 ; $i <= $number_of_pages; $i++) {
               $theclone = $info[$child];
               $theclone['data'][$labelmap] =  $theclone['data'][$labelmap] . ' ' . $i;
               $theclone['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] = $i;
@@ -1002,7 +1002,6 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
 
                   if ($method[0] == 'parent_object' && $fileurl) {
                     $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
-
                     $fileurl = islandora_paged_content_extract_tiff_from_pdf($fileurl, $offset, $device, $resolution);
                     // Get path info agaain for the returned mimetype
                     $path_info = pathinfo(str_replace(" ", "\x20", trim($fileurl)));
@@ -1058,6 +1057,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                     $tmp_directory = islandora_multi_importer_temp_directory();
                     $destination = $tmp_directory.'/'.md5($fileurl).'.'.$path_info['extension'];
                     $success = TRUE;
+
                     if (!file_exists($destination)) {
                       $success = file_put_contents($destination, $fp);
                     }
@@ -1070,7 +1070,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                       $fileurl = islandora_paged_content_extract_tiff_from_pdf($destination, $offset, $device, $resolution);
                     }
 
-                    // Get path info agaain for the returned mimetype
+                    // Get path info again for the returned mimetype
                     $path_info = pathinfo(str_replace(" ", "\x20", trim($fileurl)));
                     $themime = "image/tiff";
                   }

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -329,7 +329,7 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
       // Right now we only accept PDFs in a Book or Newspaper
       // Pages (1 or more) will have a special "parent OBJ" mapping
       // But we do not need to check the CMODEL since the UI limits who can already
-      if (isset($this->parameters['cmodel_mapping'][$objectInfo['cmodel']]['dsid']['OBJ'])) {
+      if (isset($this->parameters['cmodel_mapping'][$objectInfo['cmodel']]['dsid']['rows']['OBJ'])) {
         $howtogenerate = $this->parameters['cmodel_mapping'][$objectInfo['cmodel']]['dsid']['rows']['OBJ'];
         // We do not have access to the parent yet here. So we just flag it
         if (strpos($howtogenerate['method']['data'], "parent_object|") === 0 ) {

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -549,7 +549,6 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
             // First update sequence number of the first one to 1
             $info[$child]['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] = 1;
             $labelmap = $this->parameters['object_maping']['labelmap_row']['labelmap'];
-            $info[$child]['data'][$labelmap] = $info[$child]['data'][$labelmap] . ' ' . 1;
              // because yea, maybe someone just got one!
             for($i = 1 ; $i < $number_of_pages; $i++) {
               $theclone = $info[$child];
@@ -557,6 +556,8 @@ class IslandoraMultiBatch extends IslandoraBatchPreprocessor {
               $theclone['data'][$this->parameters['object_maping']['sequencemap_row']['sequencemap']] = $i;
               $info[] = $theclone;
             }
+            // Only add the 1 once we added all the clones.
+            $info[$child]['data'][$labelmap] = $info[$child]['data'][$labelmap] . ' ' . 1;
             $namespace = $info[$child]['namespace'];
             // One less since we already had the 0 sequence master page.
             $namespace_count[$namespace] = $namespace_count[$namespace] + $number_of_pages - 1;

--- a/includes/islandora_multi_batch.inc
+++ b/includes/islandora_multi_batch.inc
@@ -967,6 +967,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
               $opened = $z->open($this->preprocessorParameters['zipfile']);
               if ($opened === TRUE) {
                 $fp = $z->getStream($this->objectInfo['data'][$method[1]]);
+                error_log($this->objectInfo['data'][$method[1]]);
                 if (!$fp) {
                     $errors[] = t('For Object %id, %dsid datastream: We could not find the source %file file in the expected location, will try to get it remotely',
                     array(
@@ -1036,7 +1037,7 @@ class IslandoraMultiBatchObject extends IslandoraBatchObject {
                   if ($method[0] == 'parent_object') {
                     $offset = trim($this->objectInfo['data'][$this->preprocessorParameters['object_maping']['sequencemap_row']['sequencemap']]);
 
-                    error_log($this->objectInfo['data'][$method[1]]);
+                    error_log($fileurl);
                     error_log($device);
                     error_log($offset);
                     $fileurl = islandora_paged_content_extract_tiff_from_pdf($fileurl, $offset, $device, $resolution);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -244,7 +244,7 @@ function islandora_multi_importer_remote_file_get($url) {
     $localfile = file_build_uri(drupal_basename($parsed_url['path']));
     if (!file_exists($localfile)) {
       // Actual remote heavy lifting only if not present.
-      $localfile = islandora_multi_importer_retrieve_remote_file($url, $local, FILE_EXISTS_REPLACE);
+      $localfile = islandora_multi_importer_retrieve_remote_file($url, $localfile, FILE_EXISTS_REPLACE);
       return $localfile;
     }
     else {
@@ -533,8 +533,8 @@ function islandora_multi_importer_array_combine_special($header, $row) {
 /**
  * Match different sized arrays.
  *
- * @param array $headercount
- *   an array lenght to check against.
+ * @param integer $headercount
+ *   an array length to check against.
  * @param array $row
 *   a CSV data row
  *


### PR DESCRIPTION
# What is this?

After cleaning up all what i thought was actually working (and not) and committing too many silly pieces of code the PDF to TIFF to pages auto-magic processor is done. (may have more bugs but nothing we can not fix during daylight and some good coffee)

What/how this work?

Paged CMODELS now have an extra mapping option for their OBJ datastream )(scroll down on the list when doing the CMODEL mapping). This option allows the page to a Parent Object's (Book/Newspaper Issue) assigned PDF file (in the column of your choice). 
If you actually create all the rows with Pages, IMI will respect those and only extract  from PDF to tiff the sequences stated in each Sequence column. But. If you care little about page level metadata or you have all the same in each, create a single Page  with a sequence number of 0. That is the secret command that tells archipelago to create the Pages for you. 

And it works. Yes. Please send coffee!